### PR TITLE
fix(switch): prevent keyboard from pushing CNSwitch upward (#4)

### DIFF
--- a/ios/Classes/Shared/SwitchShared.swift
+++ b/ios/Classes/Shared/SwitchShared.swift
@@ -4,6 +4,14 @@ struct CupertinoSwitchView: View {
   @ObservedObject var model: SwitchModel
 
   var body: some View {
+    configuredToggle
+      // Prevent SwiftUI's automatic keyboard-avoidance from pushing the
+      // switch upward when the on-screen keyboard appears (Issue #4).
+      .ignoresSafeArea(.keyboard)
+  }
+
+  @ViewBuilder
+  private var configuredToggle: some View {
     let base = Toggle("", isOn: $model.value)
       .labelsHidden()
       .disabled(!model.enabled)

--- a/ios/Classes/Views/CupertinoSwitchPlatformView.swift
+++ b/ios/Classes/Views/CupertinoSwitchPlatformView.swift
@@ -32,6 +32,11 @@ class CupertinoSwitchPlatformView: NSObject, FlutterPlatformView {
     if #available(iOS 13.0, *) {
       self.hostingController.overrideUserInterfaceStyle = isDark ? .dark : .light
     }
+    // Prevent the hosting controller from resizing itself in response to the
+    // keyboard, which would push the switch upward (Issue #4).
+    if #available(iOS 16.0, *) {
+      self.hostingController.sizingOptions = .intrinsicContentSize
+    }
     super.init()
 
     if let tint = initialTint {


### PR DESCRIPTION
Fixes #4

## Problem

When a text field above or near a `CNSwitch` receives focus, the keyboard pushes the switch out of its intended position. This is caused by the default keyboard avoidance behaviour of `UIHostingController`.

## Changes

**`SwitchShared.swift`**
- Wraps the `Toggle` in a `configuredToggle` `@ViewBuilder`
- Applies `.ignoresSafeArea(.keyboard)` on the root `body` to disable SwiftUI's automatic keyboard avoidance

**`CupertinoSwitchPlatformView.swift`**
- Sets `hostingController.sizingOptions = .intrinsicContentSize` on iOS 16+ to prevent the hosting controller from resizing in response to the keyboard

Made with [Cursor](https://cursor.com)