### PR TITLE
feat(tab-bar): add labelFontFamily and labelFontSize to CNTabBar (#16)

### DIFF
--- a/ios/Classes/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/Classes/Views/CupertinoTabBarPlatformView.swift
@@ -29,6 +29,8 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
   private var rightInsetVal: CGFloat = 0
   private var splitSpacingVal: CGFloat = 12 // Apple's recommended spacing for visual separation
   private var currentIconSizes: [CGFloat] = [] // Track icon sizes for dynamic height calculation
+  private var labelFontFamily: String? = nil
+  private var labelFontSize: CGFloat = 0 // 0 means system default (~10pt)
 
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "CupertinoNativeTabBar_\(viewId)", binaryMessenger: messenger)
@@ -95,6 +97,7 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
       if let sp = dict["splitSpacing"] as? NSNumber { splitSpacingVal = CGFloat(truncating: sp) }
       // content insets controlled by Flutter padding; keep zero here
     }
+    // Font is read after super.init() below to use self.
 
     // Preload SVG assets dynamically based on what's actually being used
     let allAssetPaths = Set(imageAssetPaths + activeImageAssetPaths).filter { !$0.isEmpty }
@@ -116,16 +119,9 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     if #available(iOS 13.0, *) { container.overrideUserInterfaceStyle = isDark ? .dark : .light }
 
     let appearance: UITabBarAppearance? = {
-    if #available(iOS 13.0, *) {
-      let ap = UITabBarAppearance()
-      ap.configureWithTransparentBackground()
-      // Remove shadow to prevent shadow appearing over modals/bottom sheets
-      ap.shadowColor = .clear
-      ap.shadowImage = UIImage()
-      return ap
-    }
-    return nil
-  }()
+      if #available(iOS 13.0, *) { return self.makeAppearance() }
+      return nil
+    }()
     func buildItems(_ range: Range<Int>) -> [UITabBarItem] {
       var items: [UITabBarItem] = []
       for i in range {
@@ -363,6 +359,11 @@ class CupertinoTabBarPlatformView: NSObject, FlutterPlatformView, UITabBarDelega
     self.leftInsetVal = leftInset
     self.rightInsetVal = rightInset
     self.currentIconSizes = sizes.compactMap { $0 }.map { CGFloat(truncating: $0) }
+    // Read custom label font from creation params
+    if let dict = args as? [String: Any] {
+      if let ff = dict["labelFontFamily"] as? String, !ff.isEmpty { self.labelFontFamily = ff }
+      if let fs = dict["labelFontSize"] as? NSNumber, fs.doubleValue > 0 { self.labelFontSize = CGFloat(truncating: fs) }
+    }
 channel.setMethodCallHandler { [weak self] call, result in
       guard let self = self else { result(nil); return }
       switch call.method {
@@ -535,13 +536,7 @@ channel.setMethodCallHandler { [weak self] call, result in
           let imageAssetFormats = self.currentImageAssetFormats
           let activeImageAssetFormats = self.currentActiveImageAssetFormats
           let appearance: UITabBarAppearance? = {
-            if #available(iOS 13.0, *) {
-              let ap = UITabBarAppearance()
-              ap.configureWithTransparentBackground()
-              ap.shadowColor = .clear
-              ap.shadowImage = UIImage()
-              return ap
-            }
+            if #available(iOS 13.0, *) { return self.makeAppearance() }
             return nil
           }()
           let iconSizes = self.currentIconSizes
@@ -828,6 +823,28 @@ channel.setMethodCallHandler { [weak self] call, result in
           }
           result(nil)
         } else { result(FlutterError(code: "bad_args", message: "Missing badges", details: nil)) }
+      case "setFont":
+        // Update label font and re-apply appearance to all tab bars
+        if let args = call.arguments as? [String: Any] {
+          if let ff = args["labelFontFamily"] as? String { self.labelFontFamily = ff.isEmpty ? nil : ff }
+          if let fs = args["labelFontSize"] as? NSNumber, fs.doubleValue > 0 { self.labelFontSize = CGFloat(truncating: fs) }
+          if #available(iOS 13.0, *) {
+            let ap = self.makeAppearance()
+            if let bar = self.tabBar {
+              bar.standardAppearance = ap
+              if #available(iOS 15.0, *) { bar.scrollEdgeAppearance = ap }
+            }
+            if let left = self.tabBarLeft {
+              left.standardAppearance = ap
+              if #available(iOS 15.0, *) { left.scrollEdgeAppearance = ap }
+            }
+            if let right = self.tabBarRight {
+              right.standardAppearance = ap
+              if #available(iOS 15.0, *) { right.scrollEdgeAppearance = ap }
+            }
+          }
+          result(nil)
+        } else { result(FlutterError(code: "bad_args", message: "Missing font args", details: nil)) }
       case "refresh":
         // Force refresh for label rendering on iOS < 16
         // UITabBar only fully layouts labels when items are selected
@@ -926,6 +943,34 @@ channel.setMethodCallHandler { [weak self] call, result in
   }
 
   func view() -> UIView { container }
+
+  // MARK: - Appearance helpers
+
+  /// Builds a UITabBarAppearance with transparent background and optional custom label font.
+  @available(iOS 13.0, *)
+  private func makeAppearance() -> UITabBarAppearance {
+    let ap = UITabBarAppearance()
+    ap.configureWithTransparentBackground()
+    ap.shadowColor = .clear
+    ap.shadowImage = UIImage()
+    applyLabelFont(to: ap)
+    return ap
+  }
+
+  /// Applies the current label font to a UITabBarAppearance.
+  @available(iOS 13.0, *)
+  private func applyLabelFont(to ap: UITabBarAppearance) {
+    guard let fontFamily = labelFontFamily, !fontFamily.isEmpty else { return }
+    let size = labelFontSize > 0 ? labelFontSize : 10.0
+    let font = UIFont(name: fontFamily, size: size) ?? UIFont.systemFont(ofSize: size)
+    let attrs: [NSAttributedString.Key: Any] = [.font: font]
+    ap.stackedLayoutAppearance.normal.titleTextAttributes = attrs
+    ap.stackedLayoutAppearance.selected.titleTextAttributes = attrs
+    ap.inlineLayoutAppearance.normal.titleTextAttributes = attrs
+    ap.inlineLayoutAppearance.selected.titleTextAttributes = attrs
+    ap.compactInlineLayoutAppearance.normal.titleTextAttributes = attrs
+    ap.compactInlineLayoutAppearance.selected.titleTextAttributes = attrs
+  }
 
   func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
     // Single bar case

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -109,6 +109,8 @@ class CNTabBar extends StatefulWidget {
         12.0, // Apple's recommended spacing for visual separation
     this.searchItem,
     this.searchController,
+    this.labelFontFamily,
+    this.labelFontSize,
   }) : assert(items.length >= 2, 'Tab bar must have at least 2 items'),
        assert(
          items.length <= 5,
@@ -186,6 +188,29 @@ class CNTabBar extends StatefulWidget {
   /// - Listen to search state changes
   final CNTabBarSearchController? searchController;
 
+  /// Optional custom font family for tab bar item labels.
+  ///
+  /// The font must be registered in the app's `Info.plist` (iOS) or as a Flutter
+  /// font asset. When null, the system default tab bar label font is used.
+  ///
+  /// Example:
+  /// ```dart
+  /// CNTabBar(
+  ///   items: [...],
+  ///   currentIndex: _index,
+  ///   onTap: (i) => setState(() => _index = i),
+  ///   labelFontFamily: 'Roboto',
+  ///   labelFontSize: 11.0,
+  /// )
+  /// ```
+  final String? labelFontFamily;
+
+  /// Optional font size for tab bar item labels.
+  ///
+  /// Used together with [labelFontFamily]. When null, the system default size
+  /// is used (approximately 10pt on iOS).
+  final double? labelFontSize;
+
   @override
   State<CNTabBar> createState() => _CNTabBarState();
 }
@@ -206,6 +231,8 @@ class _CNTabBarState extends State<CNTabBar> {
   int? _lastRightCount;
   double? _lastSplitSpacing;
   double? _lastIconSize;
+  String? _lastLabelFontFamily;
+  double? _lastLabelFontSize;
 
   // Search state
   bool _isSearchActive = false;
@@ -460,6 +487,8 @@ class _CNTabBarState extends State<CNTabBar> {
       'sfSymbolColors': colors,
       'selectedIndex': widget.currentIndex,
       'isDark': capturedIsDark,
+      if (widget.labelFontFamily != null) 'labelFontFamily': widget.labelFontFamily,
+      if (widget.labelFontSize != null) 'labelFontSize': widget.labelFontSize,
       'split': _hasSearch
           ? true
           : widget.split, // Force split when search is enabled
@@ -584,6 +613,8 @@ class _CNTabBarState extends State<CNTabBar> {
     _lastSplit = widget.split;
     _lastRightCount = widget.rightCount;
     _lastSplitSpacing = widget.splitSpacing;
+    _lastLabelFontFamily = widget.labelFontFamily;
+    _lastLabelFontSize = widget.labelFontSize;
 
     // Force refresh for label rendering (Issue #6: sporadic missing labels with 5 items).
     // First refresh after 50ms; second after 200ms for slow-to-initialize native view.
@@ -779,6 +810,18 @@ class _CNTabBarState extends State<CNTabBar> {
         _requestIntrinsicSize();
       }
 
+      // Font updates
+      if (_lastLabelFontFamily != widget.labelFontFamily ||
+          _lastLabelFontSize != widget.labelFontSize) {
+        await ch.invokeMethod('setFont', {
+          if (widget.labelFontFamily != null)
+            'labelFontFamily': widget.labelFontFamily,
+          if (widget.labelFontSize != null) 'labelFontSize': widget.labelFontSize,
+        });
+        _lastLabelFontFamily = widget.labelFontFamily;
+        _lastLabelFontSize = widget.labelFontSize;
+      }
+
       // Layout updates (split / insets)
       if (_lastSplit != widget.split ||
           _lastRightCount != widget.rightCount ||
@@ -854,24 +897,39 @@ class _CNTabBarState extends State<CNTabBar> {
 
     // If no search item, just return regular CupertinoTabBar
     if (!_hasSearch) {
-      return SizedBox(
-        height: widget.height,
-        child: CupertinoTabBar(
-          items: [
-            for (final item in widget.items)
-              BottomNavigationBarItem(
-                icon: _buildTabIcon(item, isActive: false),
-                activeIcon: _buildTabIcon(item, isActive: true),
-                label: item.label,
-              ),
-          ],
-          currentIndex: widget.currentIndex,
-          onTap: widget.onTap,
-          backgroundColor: widget.backgroundColor,
-          inactiveColor: CupertinoColors.inactiveGray,
-          activeColor: tintColor,
-        ),
+      Widget tabBar = CupertinoTabBar(
+        items: [
+          for (final item in widget.items)
+            BottomNavigationBarItem(
+              icon: _buildTabIcon(item, isActive: false),
+              activeIcon: _buildTabIcon(item, isActive: true),
+              label: item.label,
+            ),
+        ],
+        currentIndex: widget.currentIndex,
+        onTap: widget.onTap,
+        backgroundColor: widget.backgroundColor,
+        inactiveColor: CupertinoColors.inactiveGray,
+        activeColor: tintColor,
       );
+
+      // Apply custom font family via CupertinoTheme when specified.
+      // CupertinoTabBar derives its label style from the theme typography.
+      if (widget.labelFontFamily != null) {
+        tabBar = CupertinoTheme(
+          data: CupertinoTheme.of(context).copyWith(
+            textTheme: CupertinoTheme.of(context).textTheme.copyWith(
+              tabLabelTextStyle: TextStyle(
+                fontFamily: widget.labelFontFamily,
+                fontSize: widget.labelFontSize ?? 10.0,
+              ),
+            ),
+          ),
+          child: tabBar,
+        );
+      }
+
+      return SizedBox(height: widget.height, child: tabBar);
     }
 
     // With search: build a custom layout that mimics iOS 26 behavior
@@ -972,43 +1030,51 @@ class _CNTabBarState extends State<CNTabBar> {
         mainAxisSize: MainAxisSize.min,
         children: [
           for (int i = 0; i < widget.items.length; i++)
-            GestureDetector(
-              onTap: () => widget.onTap(i),
-              child: Padding(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 6,
-                ),
-                child: Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    SizedBox(
-                      width: 20,
-                      height: 20,
-                      child: FittedBox(
-                        child: _buildTabIcon(
-                          widget.items[i],
-                          isActive: widget.currentIndex == i,
+            Flexible(
+              child: GestureDetector(
+                onTap: () => widget.onTap(i),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: FittedBox(
+                          child: _buildTabIcon(
+                            widget.items[i],
+                            isActive: widget.currentIndex == i,
+                          ),
                         ),
                       ),
-                    ),
-                    if (widget.items[i].label != null &&
-                        widget.items[i].label!.isNotEmpty) ...[
-                      const SizedBox(width: 4),
-                      Text(
-                        widget.items[i].label!,
-                        style: TextStyle(
-                          fontSize: 12,
-                          fontWeight: widget.currentIndex == i
-                              ? FontWeight.w600
-                              : FontWeight.normal,
-                          color: widget.currentIndex == i
-                              ? tintColor
-                              : CupertinoColors.inactiveGray,
+                      if (widget.items[i].label != null &&
+                          widget.items[i].label!.isNotEmpty) ...[
+                        const SizedBox(width: 4),
+                        Flexible(
+                          child: Text(
+                            widget.items[i].label!,
+                            style: TextStyle(
+                              fontFamily: widget.labelFontFamily,
+                              fontSize:
+                                  widget.labelFontSize ?? 12,
+                              fontWeight: widget.currentIndex == i
+                                  ? FontWeight.w600
+                                  : FontWeight.normal,
+                              color: widget.currentIndex == i
+                                  ? tintColor
+                                  : CupertinoColors.inactiveGray,
+                            ),
+                            overflow: TextOverflow.ellipsis,
+                            maxLines: 1,
+                          ),
                         ),
-                      ),
+                      ],
                     ],
-                  ],
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
Fixes #16

## Changes

**Dart (`tab_bar.dart`)**
- Adds `labelFontFamily` (`String?`) and `labelFontSize` (`double?`) parameters to `CNTabBar`
- Passes them as `creationParams` to the native platform view
- Detects changes in `_syncPropsToNativeIfNeeded()` and invokes a native `setFont` method channel call
- Flutter fallback (`_buildFlutterFallback`) applies the custom font via `CupertinoTheme.tabLabelTextStyle` and `TextStyle`

**Swift (`CupertinoTabBarPlatformView.swift`)**
- Reads `labelFontFamily` and `labelFontSize` from `creationParams`
- Introduces `makeAppearance()` helper that creates a `UITabBarAppearance` with transparent background and `titleTextAttributes` for normal/selected states across all layouts (stacked, inline, compactInline)
- Adds a `setFont` method channel handler for dynamic font updates at runtime

## Usage

```dart
CNTabBar(
  labelFontFamily: 'SF Pro Rounded',
  labelFontSize: 10.0,
  tabs: [...],
)
```

Made with [Cursor](https://cursor.com)