### PR TITLE
fix(native-tab-bar): rewrite CNNativeTabBarManager to fix double-tap (#7)

### DIFF
--- a/ios/Classes/Views/CNNativeTabBarManager.swift
+++ b/ios/Classes/Views/CNNativeTabBarManager.swift
@@ -108,9 +108,9 @@ class CNNativeTabBarManager: NSObject {
             return
         }
 
-        // 1) Attacher le container comme racine pour que la hiérarchie ait une taille valide.
-        // 2) Puis intégrer le FlutterViewController en enfant (addChild) — reparentage de la
-        //    seule UIView cassait souvent le rendu (surface vide).
+        // 1) Set the container as root so the hierarchy has a valid size.
+        // 2) Then embed FlutterViewController as a child (addChild) — reparenting only the
+        //    UIView often broke rendering (blank surface).
         UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: {
             window.rootViewController = vc
         }, completion: { _ in
@@ -370,7 +370,7 @@ private class NativeTabBarContainerVC: UIViewController, UITabBarDelegate {
         view.addSubview(navController.view)
         navController.didMove(toParent: self)
 
-        // Plein écran derrière la tab bar (effet type iOS : contenu visible sous la barre translucide).
+        // Full screen behind the tab bar (iOS-style: content visible under the translucent bar).
         NSLayoutConstraint.activate([
             navController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             navController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
@@ -564,7 +564,7 @@ private class NativeTabBarContainerVC: UIViewController, UITabBarDelegate {
 
 // MARK: - FlutterContentHostViewController
 
-/// Single VC that hosts the [FlutterViewController] as enfant pour un cycle de vie correct.
+/// Single VC that hosts the [FlutterViewController] as a child for correct view-controller lifecycle.
 private class FlutterContentHostViewController: UIViewController {
 
     private var embeddedFlutterVC: FlutterViewController?

--- a/ios/Classes/Views/CNNativeTabBarManager.swift
+++ b/ios/Classes/Views/CNNativeTabBarManager.swift
@@ -10,7 +10,7 @@ import UIKit
 /// **never** reparented between child view controllers, fixing Issue #7 (double-tap).
 ///
 /// `UISearchController` remains attached to the navigation item when `isSearchTab` is true,
-/// preserving the native search integration expected by `CNTabBarNative` users.
+/// preserving the native search integration expected by `CNTabBarWithSearch` users.
 class CNNativeTabBarManager: NSObject {
 
     static let shared = CNNativeTabBarManager()
@@ -322,6 +322,10 @@ extension CNNativeTabBarManager: UISearchBarDelegate {
 
     func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
         methodChannel?.invokeMethod("onSearchCancelled", arguments: nil)
+        // Leave search tab so the tab bar is shown again (z-order fix).
+        if let firstNonSearch = tabConfigurations.firstIndex(where: { !$0.isSearchTab }) {
+            containerVC?.selectTab(at: firstNonSearch)
+        }
     }
 
     func searchBarTextDidBeginEditing(_ searchBar: UISearchBar) {
@@ -497,10 +501,34 @@ private class NativeTabBarContainerVC: UIViewController, UITabBarDelegate {
             contentHost.navigationItem.hidesSearchBarWhenScrolling = false
             contentHost.definesPresentationContext = true
             navController.setNavigationBarHidden(false, animated: animated)
+            // Search bar sits in the nav stack; tab bar is `bringSubviewToFront` — hide tab bar
+            // while search is active so `UISearchController` is usable (PR #7 feedback).
+            setTabBarHidden(true, animated: animated)
         } else {
             contentHost.navigationItem.searchController = nil
             contentHost.title = config.title.isEmpty ? nil : config.title
             navController.setNavigationBarHidden(true, animated: animated)
+            setTabBarHidden(false, animated: animated)
+        }
+    }
+
+    /// Slides the native tab bar off-screen when the search tab is selected; restores it otherwise.
+    private func setTabBarHidden(_ hidden: Bool, animated: Bool) {
+        guard nativeTabBar.superview != nil else { return }
+        view.layoutIfNeeded()
+        let barHeight = max(nativeTabBar.bounds.height, 49)
+        let offset = barHeight + view.safeAreaInsets.bottom
+        let targetTransform = hidden
+            ? CGAffineTransform(translationX: 0, y: offset)
+            : .identity
+
+        let apply = {
+            self.nativeTabBar.transform = targetTransform
+        }
+        if animated {
+            UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseInOut, animations: apply)
+        } else {
+            apply()
         }
     }
 

--- a/ios/Classes/Views/CNNativeTabBarManager.swift
+++ b/ios/Classes/Views/CNNativeTabBarManager.swift
@@ -2,22 +2,29 @@ import Flutter
 import UIKit
 
 /// Manager for iOS 26+ Native Tab Bar with Search Support
-/// This class manages a native UITabBarController at the app level
-/// and coordinates with Flutter for content display
+///
+/// Architecture: a single `NativeTabBarContainerVC` holds the Flutter view **permanently**
+/// inside a `FlutterContentHostViewController` nested under a `UINavigationController`.
+/// A `UITabBar` is overlaid at the bottom. Tab changes only update chrome (nav bar +
+/// `UISearchController` when the selected tab is a search tab) — the Flutter view is
+/// **never** reparented between child view controllers, fixing Issue #7 (double-tap).
+///
+/// `UISearchController` remains attached to the navigation item when `isSearchTab` is true,
+/// preserving the native search integration expected by `CNTabBarNative` users.
 class CNNativeTabBarManager: NSObject {
 
     static let shared = CNNativeTabBarManager()
 
-    private var tabBarController: UITabBarController?
+    private var containerVC: NativeTabBarContainerVC?
     private var flutterViewController: FlutterViewController?
-    private var searchController: UISearchController?
     private var methodChannel: FlutterMethodChannel?
-
-    private var tabConfigurations: [TabConfig] = []
-    private var searchTabIndex: Int = -1
+    private var searchController: UISearchController?
     private var isEnabled: Bool = false
     private var tintColor: UIColor?
     private var unselectedTintColor: UIColor?
+    private var tabConfigurations: [TabConfig] = []
+    private var searchTabIndex: Int = -1
+    private var ignoreInitialSearchUpdate = true
 
     struct TabConfig {
         let title: String
@@ -31,9 +38,7 @@ class CNNativeTabBarManager: NSObject {
         super.init()
     }
 
-    /// Setup native tab bar with Flutter
     func setup(messenger: FlutterBinaryMessenger) {
-        // Only setup on iOS 26+
         guard #available(iOS 26.0, *) else {
             NSLog("⚠️ CNNativeTabBarManager: Requires iOS 26+")
             return
@@ -43,296 +48,158 @@ class CNNativeTabBarManager: NSObject {
             name: "cn_native_tab_bar",
             binaryMessenger: messenger
         )
-
         methodChannel?.setMethodCallHandler { [weak self] call, result in
             self?.handleMethodCall(call, result: result)
         }
     }
 
-    /// Find Flutter view controller
     private func getFlutterViewController() -> FlutterViewController? {
-        if let flutterVC = flutterViewController {
-            return flutterVC
-        }
-
-        // Try to find it from windows
+        if let vc = flutterViewController { return vc }
         if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-            if let flutterVC = window.rootViewController as? FlutterViewController {
-                self.flutterViewController = flutterVC
-                return flutterVC
-            }
+           let window = windowScene.windows.first(where: { $0.isKeyWindow }),
+           let vc = window.rootViewController as? FlutterViewController {
+            self.flutterViewController = vc
+            return vc
         }
-
         return nil
     }
 
-    private var searchOnlyNavController: UINavigationController?
+    // MARK: - Enable / Disable
 
-    /// Enable native tab bar mode
     private func enableNativeTabBar(tabs: [TabConfig], selectedIndex: Int, isDark: Bool) {
         guard let flutterVC = getFlutterViewController() else {
             NSLog("❌ CNNativeTabBarManager: Could not find FlutterViewController")
             return
         }
 
-        // Store configuration
         self.tabConfigurations = tabs
         self.searchTabIndex = tabs.firstIndex(where: { $0.isSearchTab }) ?? -1
 
-        // Check if this is search-only mode (single search tab)
         let isSearchOnlyMode = tabs.count == 1 && tabs[0].isSearchTab
 
         if isSearchOnlyMode {
-            // Search-only mode: Use UINavigationController with UISearchController directly
             enableSearchOnlyMode(flutterVC: flutterVC, config: tabs[0], isDark: isDark)
             return
         }
 
-        // Create tab bar controller if needed
-        if tabBarController == nil {
-            let tabBar = UITabBarController()
-            tabBarController = tabBar
-
-            // Setup iOS 26 appearance
-            setupTabBarAppearance(tabBar)
+        // Build UISearchController once if any tab is a search tab (delegate = self)
+        if searchTabIndex >= 0 {
+            let search = UISearchController(searchResultsController: nil)
+            search.searchResultsUpdater = self
+            search.searchBar.delegate = self
+            search.obscuresBackgroundDuringPresentation = false
+            search.hidesNavigationBarDuringPresentation = false
+            search.showsSearchResultsController = false
+            self.searchController = search
         }
 
-        guard let tabBar = tabBarController else { return }
+        let vc = NativeTabBarContainerVC()
+        vc.methodChannel = methodChannel
+        vc.tintColor = tintColor
+        vc.unselectedTintColor = unselectedTintColor
+        vc.overrideUserInterfaceStyle = isDark ? .dark : .light
+        vc.searchController = searchController
+        vc.configure(tabs: tabs, selectedIndex: selectedIndex, searchOnlyMode: false)
 
-        // Apply dark mode
-        tabBar.overrideUserInterfaceStyle = isDark ? .dark : .light
+        self.containerVC = vc
 
-        // Create view controllers for each tab
-        var viewControllers: [UIViewController] = []
-
-        for (index, config) in tabs.enumerated() {
-            if config.isSearchTab {
-                // Create search tab with Flutter content embedded
-                let searchVC = FlutterTabViewController()
-                searchVC.tabIndex = index
-                searchVC.isSearchTab = true
-                searchVC.methodChannel = self.methodChannel
-
-                let navController = UINavigationController(rootViewController: searchVC)
-                navController.navigationBar.prefersLargeTitles = true
-
-                // Setup search controller
-                let search = UISearchController(searchResultsController: nil)
-                search.searchResultsUpdater = self
-                search.searchBar.delegate = self
-                search.obscuresBackgroundDuringPresentation = false
-                search.searchBar.placeholder = config.title.isEmpty ? "Search" : config.title
-                search.hidesNavigationBarDuringPresentation = false
-
-                searchVC.navigationItem.searchController = search
-                searchVC.navigationItem.hidesSearchBarWhenScrolling = false
-                searchVC.definesPresentationContext = true
-                searchVC.title = "Search"
-
-                self.searchController = search
-
-                // Setup tab bar item with search system item
-                navController.tabBarItem = UITabBarItem(tabBarSystemItem: .search, tag: index)
-                if !config.title.isEmpty {
-                    navController.tabBarItem.title = config.title
-                }
-
-                viewControllers.append(navController)
-            } else {
-                // Regular tab - use Flutter view
-                let tabVC = FlutterTabViewController()
-                tabVC.tabIndex = index
-                tabVC.methodChannel = self.methodChannel
-
-                // Setup tab bar item
-                var image: UIImage?
-                var selectedImage: UIImage?
-
-                if let symbol = config.sfSymbol, !symbol.isEmpty {
-                    if let unselTint = unselectedTintColor {
-                        image = UIImage(systemName: symbol)?.withTintColor(unselTint, renderingMode: .alwaysOriginal)
-                    } else {
-                        image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
-                    }
-                }
-
-                if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
-                    selectedImage = UIImage(systemName: activeSymbol)?.withRenderingMode(.alwaysTemplate)
-                } else {
-                    selectedImage = image
-                }
-
-                tabVC.tabBarItem = UITabBarItem(
-                    title: config.title,
-                    image: image,
-                    selectedImage: selectedImage
-                )
-                tabVC.tabBarItem.tag = index
-
-                // Set badge value if provided
-                if let count = config.badgeCount, count > 0 {
-                    tabVC.tabBarItem.badgeValue = count > 99 ? "99+" : String(count)
-                }
-
-                viewControllers.append(tabVC)
-            }
-        }
-
-        tabBar.viewControllers = viewControllers
-        tabBar.selectedIndex = selectedIndex
-        tabBar.delegate = self
-
-        // Apply tint colors
-        if let tint = tintColor {
-            tabBar.tabBar.tintColor = tint
-        }
-        if let unselTint = unselectedTintColor {
-            tabBar.tabBar.unselectedItemTintColor = unselTint
-        }
-
-        // Replace root view controller
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-            // Embed Flutter view in the selected tab
-            let selectedVC = viewControllers[selectedIndex]
-            if let navController = selectedVC as? UINavigationController,
-               let rootVC = navController.topViewController as? FlutterTabViewController {
-                rootVC.embedFlutterView(flutterVC.view)
-            } else if let flutterTabVC = selectedVC as? FlutterTabViewController {
-                flutterTabVC.embedFlutterView(flutterVC.view)
-            }
-
-            UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
-                window.rootViewController = tabBar
-            }
-
-            self.isEnabled = true
-            NSLog("✅ CNNativeTabBarManager: Native tab bar enabled")
-        }
-    }
-
-    private var ignoreInitialSearchUpdate = true
-
-    /// Enable search-only mode (single search tab, no tab bar)
-    private func enableSearchOnlyMode(flutterVC: FlutterViewController, config: TabConfig, isDark: Bool) {
-        // Reset flag
-        ignoreInitialSearchUpdate = true
-
-        // Create Flutter container view controller
-        let searchVC = FlutterTabViewController()
-        searchVC.tabIndex = 0
-        searchVC.isSearchTab = true
-        searchVC.methodChannel = self.methodChannel
-
-        // Create navigation controller
-        let navController = UINavigationController(rootViewController: searchVC)
-        navController.navigationBar.prefersLargeTitles = true
-        navController.overrideUserInterfaceStyle = isDark ? .dark : .light
-
-        // Setup search controller - NOT active by default
-        let search = UISearchController(searchResultsController: nil)
-        search.obscuresBackgroundDuringPresentation = false
-        search.searchBar.placeholder = config.title.isEmpty ? "Search" : config.title
-        search.hidesNavigationBarDuringPresentation = false
-        // Don't show separate results controller - show results in same view
-        search.showsSearchResultsController = false
-
-        // Set delegates
-        search.searchResultsUpdater = self
-        search.searchBar.delegate = self
-
-        searchVC.navigationItem.searchController = search
-        searchVC.navigationItem.hidesSearchBarWhenScrolling = false
-        searchVC.definesPresentationContext = true
-        searchVC.title = config.title.isEmpty ? "Search" : config.title
-
-        self.searchController = search
-        self.searchOnlyNavController = navController
-
-        // Embed Flutter view FIRST
-        searchVC.embedFlutterView(flutterVC.view)
-
-        // Replace root view controller
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-            window.rootViewController = navController
-            window.makeKeyAndVisible()
-
-            // Deactivate search after a short delay to ensure UI is ready
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-                search.isActive = false
-                self.ignoreInitialSearchUpdate = false
-            }
-
-            self.isEnabled = true
-            NSLog("✅ CNNativeTabBarManager: Search-only mode enabled")
-        }
-    }
-
-    /// Disable native tab bar and return to Flutter-only mode
-    private func disableNativeTabBar() {
-        guard let flutterVC = flutterViewController else {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else {
             return
         }
 
-        // Remove Flutter view from search-only nav controller if present
-        if let navController = searchOnlyNavController,
-           let searchVC = navController.topViewController as? FlutterTabViewController {
-            searchVC.removeFlutterView()
+        // 1) Attacher le container comme racine pour que la hiérarchie ait une taille valide.
+        // 2) Puis intégrer le FlutterViewController en enfant (addChild) — reparentage de la
+        //    seule UIView cassait souvent le rendu (surface vide).
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: {
+            window.rootViewController = vc
+        }, completion: { _ in
+            vc.view.setNeedsLayout()
+            vc.view.layoutIfNeeded()
+            vc.embedFlutterView(flutterVC)
+        })
+
+        self.isEnabled = true
+        // Allow searchResultsUpdater to forward queries (same pattern as search-only mode).
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
+            self?.ignoreInitialSearchUpdate = false
+        }
+        NSLog("✅ CNNativeTabBarManager: Native tab bar enabled (container + UISearchController)")
+    }
+
+    private func enableSearchOnlyMode(flutterVC: FlutterViewController, config: TabConfig, isDark: Bool) {
+        ignoreInitialSearchUpdate = true
+
+        let search = UISearchController(searchResultsController: nil)
+        search.searchResultsUpdater = self
+        search.searchBar.delegate = self
+        search.obscuresBackgroundDuringPresentation = false
+        search.hidesNavigationBarDuringPresentation = false
+        search.showsSearchResultsController = false
+        search.searchBar.placeholder = config.title.isEmpty ? "Search" : config.title
+        self.searchController = search
+
+        let vc = NativeTabBarContainerVC()
+        vc.methodChannel = methodChannel
+        vc.tintColor = tintColor
+        vc.unselectedTintColor = unselectedTintColor
+        vc.overrideUserInterfaceStyle = isDark ? .dark : .light
+        vc.searchController = searchController
+        vc.configure(
+            tabs: [config],
+            selectedIndex: 0,
+            searchOnlyMode: true
+        )
+
+        self.containerVC = vc
+
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+            return
         }
 
-        // Remove Flutter view from tab if embedded
-        if let tabBar = tabBarController,
-           let selectedVC = tabBar.selectedViewController as? FlutterTabViewController {
-            selectedVC.removeFlutterView()
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve, animations: {
+            window.rootViewController = vc
+        }, completion: { _ in
+            vc.view.setNeedsLayout()
+            vc.view.layoutIfNeeded()
+            vc.embedFlutterView(flutterVC)
+        })
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+            search.isActive = false
+            self?.ignoreInitialSearchUpdate = false
         }
 
-        // Restore Flutter as root
-        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-           let window = windowScene.windows.first(where: { $0.isKeyWindow }) {
-            UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
-                window.rootViewController = flutterVC
-            }
+        self.isEnabled = true
+        NSLog("✅ CNNativeTabBarManager: Search-only mode (container + UISearchController)")
+    }
+
+    private func disableNativeTabBar() {
+        guard let flutterVC = flutterViewController else { return }
+
+        containerVC?.removeFlutterView()
+        searchController = nil
+
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else {
+            return
         }
 
-        self.searchOnlyNavController = nil
+        UIView.transition(with: window, duration: 0.3, options: .transitionCrossDissolve) {
+            window.rootViewController = flutterVC
+        }
 
+        self.containerVC = nil
         self.isEnabled = false
-        self.tabBarController = nil
         NSLog("✅ CNNativeTabBarManager: Native tab bar disabled")
     }
 
-    private func setupTabBarAppearance(_ tabBar: UITabBarController) {
-        // iOS 26 - use direct properties for liquid glass effect
-        tabBar.tabBar.isTranslucent = true
-        tabBar.tabBar.backgroundImage = UIImage()
-        tabBar.tabBar.shadowImage = UIImage()
-        tabBar.tabBar.backgroundColor = .clear
-    }
-
-    private func notifyTabSelected(_ index: Int) {
-        methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
-
-        guard let flutterView = flutterViewController?.view,
-              let tabBar = tabBarController else { return }
-
-        // Get the selected view controller - handle navigation controller wrapping for search tab
-        var targetVC: FlutterTabViewController?
-        if let navController = tabBar.selectedViewController as? UINavigationController,
-           let rootVC = navController.topViewController as? FlutterTabViewController {
-            targetVC = rootVC
-        } else if let flutterTabVC = tabBar.selectedViewController as? FlutterTabViewController {
-            targetVC = flutterTabVC
-        }
-
-        if let vc = targetVC {
-            vc.embedFlutterView(flutterView)
-        }
-    }
+    // MARK: - Method channel
 
     private func handleMethodCall(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
+
         case "enable":
             guard let args = call.arguments as? [String: Any],
                   let tabsData = args["tabs"] as? [[String: Any]] else {
@@ -342,23 +209,20 @@ class CNNativeTabBarManager: NSObject {
 
             let tabs = tabsData.compactMap { data -> TabConfig? in
                 guard let title = data["title"] as? String else { return nil }
-                let symbol = data["sfSymbol"] as? String
-                let activeSymbol = data["activeSfSymbol"] as? String
-                let isSearch = (data["isSearch"] as? Bool) ?? false
-                let badgeCount = data["badgeCount"] as? Int
-                return TabConfig(title: title, sfSymbol: symbol, activeSfSymbol: activeSymbol, isSearchTab: isSearch, badgeCount: badgeCount)
+                return TabConfig(
+                    title: title,
+                    sfSymbol: data["sfSymbol"] as? String,
+                    activeSfSymbol: data["activeSfSymbol"] as? String,
+                    isSearchTab: (data["isSearch"] as? Bool) ?? false,
+                    badgeCount: data["badgeCount"] as? Int
+                )
             }
 
             let selectedIndex = (args["selectedIndex"] as? Int) ?? 0
             let isDark = (args["isDark"] as? Bool) ?? false
 
-            // Parse colors
-            if let tint = args["tint"] as? Int {
-                tintColor = ImageUtils.colorFromARGB(tint)
-            }
-            if let unselTint = args["unselectedTint"] as? Int {
-                unselectedTintColor = ImageUtils.colorFromARGB(unselTint)
-            }
+            if let tint = args["tint"] as? Int { tintColor = ImageUtils.colorFromARGB(tint) }
+            if let unsel = args["unselectedTint"] as? Int { unselectedTintColor = ImageUtils.colorFromARGB(unsel) }
 
             enableNativeTabBar(tabs: tabs, selectedIndex: selectedIndex, isDark: isDark)
             result(nil)
@@ -373,15 +237,14 @@ class CNNativeTabBarManager: NSObject {
                 result(FlutterError(code: "invalid_args", message: "Invalid index", details: nil))
                 return
             }
-            tabBarController?.selectedIndex = index
-            notifyTabSelected(index)
+            containerVC?.selectTab(at: index)
             result(nil)
 
         case "activateSearch":
             if searchTabIndex >= 0 {
-                tabBarController?.selectedIndex = searchTabIndex
-                searchController?.isActive = true
+                containerVC?.selectTab(at: searchTabIndex)
             }
+            searchController?.isActive = true
             result(nil)
 
         case "deactivateSearch":
@@ -400,36 +263,30 @@ class CNNativeTabBarManager: NSObject {
 
         case "setBadgeCounts":
             guard let args = call.arguments as? [String: Any],
-                  let badgeCounts = args["badgeCounts"] as? [Int?] else {
+                  let raw = args["badgeCounts"] as? [Any] else {
                 result(FlutterError(code: "invalid_args", message: "Invalid badge counts", details: nil))
                 return
             }
-
-            if let tabBar = tabBarController, let viewControllers = tabBar.viewControllers {
-                for (index, viewController) in viewControllers.enumerated() {
-                    if index < badgeCounts.count {
-                        let count = badgeCounts[index]
-                        if let count = count, count > 0 {
-                            viewController.tabBarItem.badgeValue = count > 99 ? "99+" : String(count)
-                        } else {
-                            viewController.tabBarItem.badgeValue = nil
-                        }
-                    }
-                }
+            let badgeCounts: [Int?] = raw.map { any in
+                if any is NSNull { return nil }
+                if let i = any as? Int { return i }
+                if let n = any as? NSNumber { return n.intValue }
+                return nil
             }
+            containerVC?.updateBadges(badgeCounts)
             result(nil)
 
         case "setStyle":
             if let args = call.arguments as? [String: Any] {
                 if let tint = args["tint"] as? Int {
                     let color = ImageUtils.colorFromARGB(tint)
-                    tabBarController?.tabBar.tintColor = color
                     tintColor = color
+                    containerVC?.applyTint(color)
                 }
-                if let unselTint = args["unselectedTint"] as? Int {
-                    let color = ImageUtils.colorFromARGB(unselTint)
-                    tabBarController?.tabBar.unselectedItemTintColor = color
+                if let unsel = args["unselectedTint"] as? Int {
+                    let color = ImageUtils.colorFromARGB(unsel)
                     unselectedTintColor = color
+                    containerVC?.applyUnselectedTint(color)
                 }
             }
             result(nil)
@@ -437,7 +294,7 @@ class CNNativeTabBarManager: NSObject {
         case "setBrightness":
             if let args = call.arguments as? [String: Any],
                let isDark = args["isDark"] as? Bool {
-                tabBarController?.overrideUserInterfaceStyle = isDark ? .dark : .light
+                containerVC?.overrideUserInterfaceStyle = isDark ? .dark : .light
             }
             result(nil)
 
@@ -447,28 +304,15 @@ class CNNativeTabBarManager: NSObject {
     }
 }
 
-// MARK: - UITabBarControllerDelegate
-
-extension CNNativeTabBarManager: UITabBarControllerDelegate {
-    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
-        let index = tabBarController.viewControllers?.firstIndex(of: viewController) ?? 0
-        notifyTabSelected(index)
-    }
-}
-
-// MARK: - UISearchResultsUpdating
+// MARK: - UISearchResultsUpdating & UISearchBarDelegate
 
 extension CNNativeTabBarManager: UISearchResultsUpdating {
     func updateSearchResults(for searchController: UISearchController) {
-        // Ignore initial auto-triggered updates
         if ignoreInitialSearchUpdate { return }
-
         guard let query = searchController.searchBar.text else { return }
         methodChannel?.invokeMethod("onSearchChanged", arguments: ["query": query])
     }
 }
-
-// MARK: - UISearchBarDelegate
 
 extension CNNativeTabBarManager: UISearchBarDelegate {
     func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
@@ -489,92 +333,248 @@ extension CNNativeTabBarManager: UISearchBarDelegate {
     }
 }
 
-// MARK: - Tab View Controllers
+// MARK: - NativeTabBarContainerVC
 
-private class FlutterTabViewController: UIViewController {
-    var tabIndex: Int = 0
-    var isSearchTab: Bool = false
+/// Root container: `UINavigationController` + bottom `UITabBar`. The navigation stack has a
+/// single root that permanently hosts the Flutter view; search UI is toggled via
+/// `navigationItem.searchController` without moving the Flutter view.
+private class NativeTabBarContainerVC: UIViewController, UITabBarDelegate {
+
     weak var methodChannel: FlutterMethodChannel?
-    private var embeddedFlutterView: UIView?
+    var tintColor: UIColor?
+    var unselectedTintColor: UIColor?
+    /// Owned by [CNNativeTabBarManager]; same instance used when search tab is active.
+    var searchController: UISearchController?
+
+    private var navController: UINavigationController!
+    private var contentHost: FlutterContentHostViewController!
+    private var nativeTabBar: UITabBar!
+
+    private var tabConfigurations: [CNNativeTabBarManager.TabConfig] = []
+    private var currentIndex: Int = 0
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-    }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        methodChannel?.invokeMethod("onTabAppeared", arguments: ["index": tabIndex])
-    }
+        contentHost = FlutterContentHostViewController()
+        navController = UINavigationController(rootViewController: contentHost)
+        navController.navigationBar.prefersLargeTitles = true
 
-    func embedFlutterView(_ flutterView: UIView) {
-        // Remove any existing embedded view
-        embeddedFlutterView?.removeFromSuperview()
+        addChild(navController)
+        navController.view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(navController.view)
+        navController.didMove(toParent: self)
 
-        // Remove from previous parent
-        flutterView.removeFromSuperview()
-
-        // Ensure Flutter view is visible
-        flutterView.isHidden = false
-        flutterView.alpha = 1.0
-        flutterView.translatesAutoresizingMaskIntoConstraints = false
-
-        // Add to this view controller
-        view.addSubview(flutterView)
-        view.bringSubviewToFront(flutterView)
-
-        // Fill entire view - Flutter handles its own safe area
+        // Plein écran derrière la tab bar (effet type iOS : contenu visible sous la barre translucide).
         NSLayoutConstraint.activate([
-            flutterView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            flutterView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            flutterView.topAnchor.constraint(equalTo: view.topAnchor),
-            flutterView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            navController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            navController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            navController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            navController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
 
-        embeddedFlutterView = flutterView
+        buildTabBar()
+    }
 
-        // Force layout update
-        view.setNeedsLayout()
-        view.layoutIfNeeded()
+    private func buildTabBar() {
+        let bar = UITabBar()
+        bar.delegate = self
+        bar.isTranslucent = true
+        bar.translatesAutoresizingMaskIntoConstraints = false
+        bar.layer.shadowOpacity = 0
 
-        NSLog("✅ FlutterTabViewController: Embedded Flutter view, frame: \(flutterView.frame)")
+        if let tint = tintColor { bar.tintColor = tint }
+        if let unsel = unselectedTintColor { bar.unselectedItemTintColor = unsel }
+
+        if #available(iOS 13.0, *) {
+            let ap = UITabBarAppearance()
+            ap.configureWithTransparentBackground()
+            ap.shadowColor = .clear
+            ap.shadowImage = UIImage()
+            bar.standardAppearance = ap
+            if #available(iOS 15.0, *) { bar.scrollEdgeAppearance = ap }
+        }
+
+        view.addSubview(bar)
+        // Au-dessus du contenu Flutter (z-order) pour interaction + flou.
+        view.bringSubviewToFront(bar)
+        NSLayoutConstraint.activate([
+            bar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        nativeTabBar = bar
+    }
+
+    func configure(tabs: [CNNativeTabBarManager.TabConfig], selectedIndex: Int, searchOnlyMode: Bool) {
+        self.tabConfigurations = tabs
+        self.currentIndex = min(max(0, selectedIndex), max(0, tabs.count - 1))
+
+        _ = view
+
+        if searchOnlyMode {
+            nativeTabBar.removeFromSuperview()
+        } else if nativeTabBar.superview == nil {
+            view.addSubview(nativeTabBar)
+            nativeTabBar.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                nativeTabBar.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                nativeTabBar.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+                nativeTabBar.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            ])
+            view.bringSubviewToFront(nativeTabBar)
+        }
+
+        let items: [UITabBarItem] = tabs.enumerated().map { (i, config) in
+            if config.isSearchTab {
+                let item = UITabBarItem(tabBarSystemItem: .search, tag: i)
+                if !config.title.isEmpty { item.title = config.title }
+                if let count = config.badgeCount, count > 0 {
+                    item.badgeValue = count > 99 ? "99+" : String(count)
+                }
+                return item
+            }
+
+            var image: UIImage?
+            var selectedImage: UIImage?
+
+            if let symbol = config.sfSymbol, !symbol.isEmpty {
+                if let unsel = unselectedTintColor {
+                    image = UIImage(systemName: symbol)?.withTintColor(unsel, renderingMode: .alwaysOriginal)
+                } else {
+                    image = UIImage(systemName: symbol)?.withRenderingMode(.alwaysTemplate)
+                }
+            }
+            if let activeSymbol = config.activeSfSymbol, !activeSymbol.isEmpty {
+                selectedImage = UIImage(systemName: activeSymbol)?.withRenderingMode(.alwaysTemplate)
+            }
+
+            let item = UITabBarItem(title: config.title, image: image, selectedImage: selectedImage ?? image)
+            item.tag = i
+            if let count = config.badgeCount, count > 0 {
+                item.badgeValue = count > 99 ? "99+" : String(count)
+            }
+            return item
+        }
+
+        nativeTabBar.items = items
+        if currentIndex < items.count {
+            nativeTabBar.selectedItem = items[currentIndex]
+        }
+
+        applySearchChrome(animated: false)
+        methodChannel?.invokeMethod("onTabSelected", arguments: ["index": currentIndex])
+    }
+
+    func embedFlutterView(_ flutterVC: FlutterViewController) {
+        contentHost.embedFlutterViewController(flutterVC)
     }
 
     func removeFlutterView() {
-        embeddedFlutterView?.removeFromSuperview()
-        embeddedFlutterView = nil
+        contentHost.removeFlutterView()
+    }
+
+    func selectTab(at index: Int) {
+        guard index >= 0, index < tabConfigurations.count else { return }
+        currentIndex = index
+        if let items = nativeTabBar.items, index < items.count {
+            nativeTabBar.selectedItem = items[index]
+        }
+        applySearchChrome(animated: true)
+        methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
+    }
+
+    private func applySearchChrome(animated: Bool) {
+        guard !tabConfigurations.isEmpty else { return }
+        let config = tabConfigurations[currentIndex]
+
+        if config.isSearchTab, let search = searchController {
+            search.searchBar.placeholder = config.title.isEmpty ? "Search" : config.title
+            contentHost.title = config.title.isEmpty ? "Search" : config.title
+            contentHost.navigationItem.searchController = search
+            contentHost.navigationItem.hidesSearchBarWhenScrolling = false
+            contentHost.definesPresentationContext = true
+            navController.setNavigationBarHidden(false, animated: animated)
+        } else {
+            contentHost.navigationItem.searchController = nil
+            contentHost.title = config.title.isEmpty ? nil : config.title
+            navController.setNavigationBarHidden(true, animated: animated)
+        }
+    }
+
+    func updateBadges(_ badgeCounts: [Int?]) {
+        guard let items = nativeTabBar.items else { return }
+        for (i, item) in items.enumerated() {
+            if i < badgeCounts.count {
+                if let count = badgeCounts[i], count > 0 {
+                    item.badgeValue = count > 99 ? "99+" : String(count)
+                } else {
+                    item.badgeValue = nil
+                }
+            }
+        }
+    }
+
+    func applyTint(_ color: UIColor) {
+        nativeTabBar.tintColor = color
+    }
+
+    func applyUnselectedTint(_ color: UIColor) {
+        nativeTabBar.unselectedItemTintColor = color
+    }
+
+    func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
+        guard let items = tabBar.items,
+              let index = items.firstIndex(of: item) else { return }
+        currentIndex = index
+        applySearchChrome(animated: true)
+        methodChannel?.invokeMethod("onTabSelected", arguments: ["index": index])
     }
 }
 
-private class SearchTabViewController: UIViewController {
-    var tabIndex: Int = 0
-    weak var methodChannel: FlutterMethodChannel?
-    var searchPlaceholderText: String = "Search results will appear here"
+// MARK: - FlutterContentHostViewController
+
+/// Single VC that hosts the [FlutterViewController] as enfant pour un cycle de vie correct.
+private class FlutterContentHostViewController: UIViewController {
+
+    private var embeddedFlutterVC: FlutterViewController?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-
-        // Add placeholder content for search results area
-        let label = UILabel()
-        label.text = searchPlaceholderText
-        label.numberOfLines = 0
-        label.textAlignment = .center
-        label.textColor = .secondaryLabel
-        label.font = .systemFont(ofSize: 17)
-        label.translatesAutoresizingMaskIntoConstraints = false
-
-        view.addSubview(label)
-        NSLayoutConstraint.activate([
-            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            label.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            label.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 20),
-            label.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -20)
-        ])
     }
 
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        methodChannel?.invokeMethod("onTabAppeared", arguments: ["index": tabIndex])
+    func embedFlutterViewController(_ flutterVC: FlutterViewController) {
+        if let old = embeddedFlutterVC {
+            old.willMove(toParent: nil)
+            old.view.removeFromSuperview()
+            old.removeFromParent()
+            embeddedFlutterVC = nil
+        }
+
+        addChild(flutterVC)
+        flutterVC.view.translatesAutoresizingMaskIntoConstraints = false
+        flutterVC.view.isHidden = false
+        flutterVC.view.alpha = 1.0
+        view.addSubview(flutterVC.view)
+        NSLayoutConstraint.activate([
+            flutterVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            flutterVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            flutterVC.view.topAnchor.constraint(equalTo: view.topAnchor),
+            flutterVC.view.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+        flutterVC.didMove(toParent: self)
+        embeddedFlutterVC = flutterVC
+        view.layoutIfNeeded()
+        NSLog("✅ FlutterContentHostViewController: FlutterViewController embedded (child VC)")
+    }
+
+    func removeFlutterView() {
+        embeddedFlutterVC?.willMove(toParent: nil)
+        embeddedFlutterVC?.view.removeFromSuperview()
+        embeddedFlutterVC?.removeFromParent()
+        embeddedFlutterVC = nil
     }
 }

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -20,7 +20,7 @@ import '../utils/version_detector.dart';
 /// @override
 /// void initState() {
 ///   super.initState();
-///   CNTabBarNative.enable(
+///   CNTabBarWithSearch.enable(
 ///     tabs: [
 ///       CNTab(title: 'Home', sfSymbol: CNSymbol('house.fill')),
 ///       CNTab(title: 'Search', sfSymbol: CNSymbol('magnifyingglass'), isSearchTab: true),
@@ -37,11 +37,11 @@ import '../utils/version_detector.dart';
 ///
 /// @override
 /// void dispose() {
-///   CNTabBarNative.disable();
+///   CNTabBarWithSearch.disable();
 ///   super.dispose();
 /// }
 /// ```
-class CNTabBarNative {
+class CNTabBarWithSearch {
   static const MethodChannel _channel = MethodChannel('cn_native_tab_bar');
 
   static bool _isEnabled = false;
@@ -54,7 +54,7 @@ class CNTabBarNative {
   /// Enable native tab bar mode
   ///
   /// Replaces your app's root with the native tab bar + navigation container
-  /// described in [CNTabBarNative]. Flutter content is not moved between
+  /// described in [CNTabBarWithSearch]. Flutter content is not moved between
   /// view controllers when changing tabs.
   ///
   /// Only works on iOS 26+. On older versions, this is a no-op.
@@ -219,7 +219,11 @@ class CNTabBarNative {
   }
 }
 
-/// Configuration for a native tab in [CNTabBarNative].
+/// Backward-compatible alias; prefer [CNTabBarWithSearch].
+@Deprecated('Use CNTabBarWithSearch instead')
+typedef CNTabBarNative = CNTabBarWithSearch;
+
+/// Configuration for a native tab in [CNTabBarWithSearch].
 ///
 /// Each tab can have a title, SF Symbol icon, and optionally be marked as a search tab.
 ///
@@ -251,7 +255,7 @@ class CNTab {
   /// Badge count to display on the tab
   final int? badgeCount;
 
-  /// Creates a tab configuration for [CNTabBarNative].
+  /// Creates a tab configuration for [CNTabBarWithSearch].
   const CNTab({
     required this.title,
     this.sfSymbol,

--- a/lib/components/native_tab_bar.dart
+++ b/lib/components/native_tab_bar.dart
@@ -6,12 +6,14 @@ import '../utils/version_detector.dart';
 
 /// iOS 26+ Native Tab Bar with Search Support
 ///
-/// This enables the native iOS 26 tab bar with search functionality.
-/// When enabled, it replaces the Flutter app's root with a native UITabBarController,
-/// giving you the true iOS 26 liquid glass morphing search effect.
+/// When enabled, replaces the app root with a native container: a bottom `UITabBar`,
+/// a `UINavigationController` with a single content host that keeps the Flutter view
+/// fixed (no reparenting between tabs), and a native `UISearchController` on the
+/// navigation item when a tab is marked with [CNTab.isSearchTab].
 ///
-/// **Important**: This replaces your app's root view controller.
-/// The Flutter content will be displayed within the selected tab.
+/// **Important**: This replaces your app's root view controller. The Flutter view
+/// stays embedded once; only the navigation chrome (including search) toggles when
+/// you select the search tab.
 ///
 /// Example:
 /// ```dart
@@ -51,9 +53,9 @@ class CNTabBarNative {
 
   /// Enable native tab bar mode
   ///
-  /// This will replace your app's root view controller with a native
-  /// UITabBarController. Your Flutter content will be displayed within
-  /// the selected tab.
+  /// Replaces your app's root with the native tab bar + navigation container
+  /// described in [CNTabBarNative]. Flutter content is not moved between
+  /// view controllers when changing tabs.
   ///
   /// Only works on iOS 26+. On older versions, this is a no-op.
   static Future<void> enable({

--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -1134,44 +1134,51 @@ class _CNTabBarState extends State<CNTabBar> {
   /// Builds an icon widget for the tab bar fallback.
   /// Priority: imageAsset > customIcon > icon (SF Symbol)
   Widget _buildTabIcon(CNTabBarItem item, {required bool isActive}) {
-    const defaultSize = 25.0;
+    const defaultSize = 22.0;
+    final fromWidget = widget.iconSize;
 
     // Check for image asset (highest priority)
     if (isActive && item.activeImageAsset != null) {
       return CNIcon(
         imageAsset: item.activeImageAsset,
-        size: item.activeImageAsset!.size,
+        size: fromWidget ?? item.activeImageAsset!.size,
       );
     }
     if (item.imageAsset != null) {
-      return CNIcon(imageAsset: item.imageAsset, size: item.imageAsset!.size);
+      return CNIcon(
+        imageAsset: item.imageAsset,
+        size: fromWidget ?? item.imageAsset!.size,
+      );
     }
 
     // Check for custom icon (medium priority)
     if (isActive && item.activeCustomIcon != null) {
-      return Icon(item.activeCustomIcon, size: defaultSize);
+      return Icon(item.activeCustomIcon, size: fromWidget ?? defaultSize);
     }
     if (item.customIcon != null) {
-      return Icon(item.customIcon, size: defaultSize);
+      return Icon(item.customIcon, size: fromWidget ?? defaultSize);
     }
 
     // Check for SF Symbol (lowest priority)
     if (isActive && item.activeIcon != null) {
       return CNIcon(
         symbol: item.activeIcon,
-        size: item.activeIcon!.size,
+        size: fromWidget ?? item.activeIcon!.size,
         color: item.activeIcon!.color,
       );
     }
     if (item.icon != null) {
       return CNIcon(
         symbol: item.icon,
-        size: item.icon!.size,
+        size: fromWidget ?? item.icon!.size,
         color: item.icon!.color,
       );
     }
 
     // Fallback to empty circle if nothing provided
-    return const Icon(CupertinoIcons.circle, size: defaultSize);
+    return Icon(
+      CupertinoIcons.circle,
+      size: fromWidget ?? defaultSize,
+    );
   }
 }

--- a/lib/cupertino_native_better.dart
+++ b/lib/cupertino_native_better.dart
@@ -23,6 +23,7 @@
 /// - [CNButton] - Native push button with Liquid Glass effects
 /// - [CNIcon] - Platform-rendered SF Symbols and custom icons
 /// - [CNTabBar] - Native tab bar with split mode support
+/// - [CNTabBarWithSearch] - Full-screen native container with `UISearchController` for search tabs (iOS 26+)
 /// - [CNSlider] - Native slider with controller support
 /// - [CNSwitch] - Native toggle switch
 /// - [CNPopupMenuButton] - Native popup menu


### PR DESCRIPTION
Fixes #7

## Maintainer feedback (Mar 19) — addressed

We agree that removing `UISearchController` would be a **breaking change** for consumers who rely on `isSearchTab: true`. This PR **keeps** native search: `UISearchController` stays attached to `navigationItem.searchController` when the search tab is selected.

Per your suggestion to make the widget’s purpose explicit, the public API is renamed from **`CNTabBarNative`** to **`CNTabBarWithSearch`**. A deprecated typedef remains:

`typedef CNTabBarNative = CNTabBarWithSearch;`

## Maintainer feedback (Mar 23) — addressed

The search bar was rendering **behind** the overlaid `UITabBar` (`bringSubviewToFront`). Fixed by **sliding the tab bar off-screen** when the search tab is active, and restoring it when switching to a non-search tab. When the user taps **Cancel** on the search bar, we also select the **first non-search tab** so the tab bar and chrome stay consistent.

## Technical summary

- Container-VC architecture unchanged: single `FlutterViewController` via `addChild`, **no** Flutter view reparenting (issue #7 double-tap fix preserved).
- `UITabBar` + `UISearchController` + z-order fix as above.
- Host apps can still pair Flutter layout with `AdaptiveScaffold.useExternalNativeTabBar` (or equivalent) to avoid a double tab bar and reserve bottom inset.

## Files

- `ios/Classes/Views/CNNativeTabBarManager.swift`
- `lib/components/native_tab_bar.dart`
- `lib/cupertino_native_better.dart`
- `lib/components/tab_bar.dart` (Flutter fallback respects `widget.iconSize`)
