### PR TITLE
Fix: `CNTabBar.iconSize` now resizes `customIcon` items too

### DIFF
--- a/lib/components/tab_bar.dart
+++ b/lib/components/tab_bar.dart
@@ -572,7 +572,14 @@ class _CNTabBarState extends State<CNTabBar> {
         // For imageAsset, we don't need to render to bytes - native code will handle it
         customIconBytes.add(null);
       } else if (item.customIcon != null) {
-        final bytes = await iconDataToImageBytes(item.customIcon!, size: 25.0);
+        // Render at the requested icon size so that bar-level `iconSize`
+        // (and per-item `icon.size` fallback) actually scales custom icons.
+        // Native side embeds these bytes as-is, so the rasterized PNG must
+        // be produced at the target logical size.
+        final bytes = await iconDataToImageBytes(
+          item.customIcon!,
+          size: widget.iconSize ?? item.icon?.size ?? 25.0,
+        );
         customIconBytes.add(bytes);
       } else {
         customIconBytes.add(null);
@@ -585,7 +592,11 @@ class _CNTabBarState extends State<CNTabBar> {
       } else if (item.activeCustomIcon != null) {
         final bytes = await iconDataToImageBytes(
           item.activeCustomIcon!,
-          size: 25.0,
+          size:
+              widget.iconSize ??
+              item.activeIcon?.size ??
+              item.icon?.size ??
+              25.0,
         );
         activeCustomIconBytes.add(bytes);
       } else if (item.customIcon != null) {
@@ -1426,6 +1437,10 @@ class _CNTabBarState extends State<CNTabBar> {
 
   /// Builds an icon widget for the tab bar fallback.
   /// Priority: imageAsset > customIcon > icon (SF Symbol)
+  ///
+  /// Mirrors the native sizing precedence used in [_prepareCreationParams]:
+  /// bar-level [CNTabBar.iconSize] wins, then per-item icon/imageAsset size,
+  /// finally the standard 25pt tab-bar icon size.
   Widget _buildTabIcon(CNTabBarItem item, {required bool isActive}) {
     const defaultSize = 25.0;
 
@@ -1433,39 +1448,48 @@ class _CNTabBarState extends State<CNTabBar> {
     if (isActive && item.activeImageAsset != null) {
       return CNIcon(
         imageAsset: item.activeImageAsset,
-        size: item.activeImageAsset!.size,
+        size: widget.iconSize ?? item.activeImageAsset!.size,
       );
     }
     if (item.imageAsset != null) {
-      return CNIcon(imageAsset: item.imageAsset, size: item.imageAsset!.size);
+      return CNIcon(
+        imageAsset: item.imageAsset,
+        size: widget.iconSize ?? item.imageAsset!.size,
+      );
     }
 
     // Check for custom icon (medium priority)
     if (isActive && item.activeCustomIcon != null) {
-      return Icon(item.activeCustomIcon, size: defaultSize);
+      return Icon(
+        item.activeCustomIcon,
+        size: widget.iconSize ?? item.activeIcon?.size ?? defaultSize,
+      );
     }
     if (item.customIcon != null) {
-      return Icon(item.customIcon, size: defaultSize);
+      return Icon(
+        item.customIcon,
+        size: widget.iconSize ?? item.icon?.size ?? defaultSize,
+      );
     }
 
     // Check for SF Symbol (lowest priority)
     if (isActive && item.activeIcon != null) {
       return CNIcon(
         symbol: item.activeIcon,
-        size: item.activeIcon!.size,
+        size: widget.iconSize ?? item.activeIcon!.size,
         color: item.activeIcon!.color,
       );
     }
     if (item.icon != null) {
       return CNIcon(
         symbol: item.icon,
-        size: item.icon!.size,
+        size: widget.iconSize ?? item.icon!.size,
         color: item.icon!.color,
       );
     }
 
     // Fallback to empty circle if nothing provided
-    return const Icon(CupertinoIcons.circle, size: defaultSize);
+    return Icon(CupertinoIcons.circle, size: widget.iconSize ?? defaultSize);
   }
 }
 

--- a/lib/utils/icon_renderer.dart
+++ b/lib/utils/icon_renderer.dart
@@ -1,7 +1,6 @@
 import 'dart:ui' as ui;
 
 import 'package:flutter/cupertino.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 
 /// Detects image format from asset path or image data.
@@ -139,62 +138,128 @@ Future<bool> _assetExists(String assetPath) async {
   }
 }
 
-/// Renders an IconData to PNG bytes for use in native platform views.
+/// Renders an [IconData] to PNG bytes for use in native platform views.
 ///
-/// The [size] parameter controls the logical pixel size of the icon.
-/// This function renders the icon at the native size and proper pixel density.
+/// The [size] parameter is the logical font size of the glyph. The returned
+/// bitmap is sized to the glyph's actual painted bounds, not to a fixed
+/// `size × size` box — square icon fonts (Material, Cupertino) round-trip at
+/// `size × size`, while fonts whose glyphs overflow their em-box (e.g.
+/// FontAwesome) get a bitmap large enough to contain the full glyph without
+/// clipping.
+///
+/// The function works in two passes:
+///   1. Lay out and paint the glyph onto a canvas with generous transparent
+///      padding on every side, large enough to contain any overflow from
+///      typical icon fonts.
+///   2. Scan the alpha channel to find the non-transparent bounding box and
+///      crop the bitmap down to that. This avoids per-font tuning and any
+///      caller-visible "overflow margin" knob.
 Future<Uint8List?> iconDataToImageBytes(
   IconData iconData, {
   double size = 25.0,
   Color color = CupertinoColors.black,
 }) async {
   try {
-    final RenderRepaintBoundary repaintBoundary = RenderRepaintBoundary();
-    final PipelineOwner pipelineOwner = PipelineOwner();
-    final BuildOwner buildOwner = BuildOwner(focusManager: FocusManager());
+    final double pixelRatio =
+        ui.PlatformDispatcher.instance.views.first.devicePixelRatio;
 
-    final RenderView renderView = RenderView(
-      view: ui.PlatformDispatcher.instance.views.first,
-      child: RenderPositionedBox(
-        alignment: Alignment.center,
-        child: repaintBoundary,
+    final TextPainter painter = TextPainter(
+      text: TextSpan(
+        text: String.fromCharCode(iconData.codePoint),
+        style: TextStyle(
+          inherit: false,
+          color: color,
+          fontSize: size,
+          fontFamily: iconData.fontFamily,
+          package: iconData.fontPackage,
+        ),
       ),
-      configuration: ViewConfiguration.fromView(
-        ui.PlatformDispatcher.instance.views.first,
-      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    // 100% of `size` of transparent headroom on every side. TextPainter
+    // reports line-box metrics, not glyph-bounds metrics, so we can't ask
+    // the engine ahead of time how far a given glyph will overflow. This
+    // is a safe upper bound for every icon font we've encountered; the
+    // overflow gets cropped away in the second pass below.
+    final double padding = size;
+    final double logicalWidth = painter.width + padding * 2;
+    final double logicalHeight = painter.height + padding * 2;
+    final int paddedPixelWidth = (logicalWidth * pixelRatio).ceil();
+    final int paddedPixelHeight = (logicalHeight * pixelRatio).ceil();
+
+    final ui.PictureRecorder recorder = ui.PictureRecorder();
+    final Canvas canvas = Canvas(recorder)..scale(pixelRatio);
+    painter.paint(canvas, Offset(padding, padding));
+    final ui.Image paddedImage = await recorder.endRecording().toImage(
+      paddedPixelWidth,
+      paddedPixelHeight,
     );
 
-    pipelineOwner.rootNode = renderView;
-    renderView.prepareInitialFrame();
-
-    final RenderObjectToWidgetElement<RenderBox> rootElement =
-        RenderObjectToWidgetAdapter<RenderBox>(
-          container: repaintBoundary,
-          child: Directionality(
-            textDirection: TextDirection.ltr,
-            child: Icon(
-              iconData,
-              size: size,
-              color: color, // Will be tinted by native platform
-            ),
-          ),
-        ).attachToRenderTree(buildOwner);
-
-    buildOwner.buildScope(rootElement);
-    buildOwner.finalizeTree();
-
-    pipelineOwner.flushLayout();
-    pipelineOwner.flushCompositingBits();
-    pipelineOwner.flushPaint();
-
-    final ui.Image image = await repaintBoundary.toImage(
-      pixelRatio: ui.PlatformDispatcher.instance.views.first.devicePixelRatio,
+    final ByteData? rgbaData = await paddedImage.toByteData(
+      format: ui.ImageByteFormat.rawStraightRgba,
     );
-    final ByteData? byteData = await image.toByteData(
+    if (rgbaData == null) {
+      paddedImage.dispose();
+      return null;
+    }
+    final Uint8List rgba = rgbaData.buffer.asUint8List();
+
+    int minX = paddedPixelWidth;
+    int minY = paddedPixelHeight;
+    int maxX = -1;
+    int maxY = -1;
+    for (int y = 0; y < paddedPixelHeight; y++) {
+      final int rowOffset = y * paddedPixelWidth * 4;
+      for (int x = 0; x < paddedPixelWidth; x++) {
+        if (rgba[rowOffset + x * 4 + 3] != 0) {
+          if (x < minX) minX = x;
+          if (x > maxX) maxX = x;
+          if (y < minY) minY = y;
+          if (y > maxY) maxY = y;
+        }
+      }
+    }
+
+    if (maxX < 0) {
+      // Nothing was painted (e.g. unknown glyph for the requested font).
+      paddedImage.dispose();
+      return null;
+    }
+
+    final int croppedPixelWidth = maxX - minX + 1;
+    final int croppedPixelHeight = maxY - minY + 1;
+
+    final ui.PictureRecorder cropRecorder = ui.PictureRecorder();
+    final Canvas cropCanvas = Canvas(cropRecorder);
+    cropCanvas.drawImageRect(
+      paddedImage,
+      Rect.fromLTWH(
+        minX.toDouble(),
+        minY.toDouble(),
+        croppedPixelWidth.toDouble(),
+        croppedPixelHeight.toDouble(),
+      ),
+      Rect.fromLTWH(
+        0,
+        0,
+        croppedPixelWidth.toDouble(),
+        croppedPixelHeight.toDouble(),
+      ),
+      Paint(),
+    );
+    final ui.Image croppedImage = await cropRecorder.endRecording().toImage(
+      croppedPixelWidth,
+      croppedPixelHeight,
+    );
+    paddedImage.dispose();
+
+    final ByteData? pngData = await croppedImage.toByteData(
       format: ui.ImageByteFormat.png,
     );
+    croppedImage.dispose();
 
-    return byteData?.buffer.asUint8List();
+    return pngData?.buffer.asUint8List();
   } catch (e) {
     debugPrint('Error rendering icon to image: $e');
     return null;

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -774,6 +774,14 @@ void main() {
     Finder iconWith(IconData data) =>
         find.byWidgetPredicate((w) => w is Icon && w.icon == data);
 
+    Widget hostTabBar(CNTabBar tabBar) {
+      return CupertinoApp(
+        home: CupertinoPageScaffold(
+          child: SafeArea(child: tabBar),
+        ),
+      );
+    }
+
     // Drains `PlatformViewGuard`'s 500ms debug-mode debounce so the test
     // doesn't fail with a "pending Timer after dispose" error when run in
     // isolation. The guard is scheduled in `_CNTabBarState.initState`.
@@ -785,24 +793,27 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CNTabBar(
-              iconSize: 32.0,
-              items: const [
-                CNTabBarItem(label: 'Home', customIcon: Icons.home),
-                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
-              ],
-              currentIndex: 0,
-              onTap: (_) {},
-            ),
+        hostTabBar(
+          CNTabBar(
+            iconSize: 32.0,
+            items: const [
+              CNTabBarItem(label: 'Home', customIcon: CupertinoIcons.house),
+              CNTabBarItem(
+                label: 'Settings',
+                customIcon: CupertinoIcons.settings,
+              ),
+            ],
+            currentIndex: 0,
+            onTap: (_) {},
           ),
         ),
       );
       await tester.pump();
 
-      final homeIcon = tester.widget<Icon>(iconWith(Icons.home));
-      final settingsIcon = tester.widget<Icon>(iconWith(Icons.settings));
+      final homeIcon = tester.widget<Icon>(iconWith(CupertinoIcons.house));
+      final settingsIcon = tester.widget<Icon>(
+        iconWith(CupertinoIcons.settings),
+      );
       expect(homeIcon.size, 32.0);
       expect(settingsIcon.size, 32.0);
 
@@ -813,28 +824,31 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CNTabBar(
-              iconSize: 28.0,
-              items: const [
-                CNTabBarItem(
-                  label: 'Home',
-                  customIcon: Icons.home_outlined,
-                  activeCustomIcon: Icons.home,
-                ),
-                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
-              ],
-              currentIndex: 0,
-              onTap: (_) {},
-            ),
+        hostTabBar(
+          CNTabBar(
+            iconSize: 28.0,
+            items: const [
+              CNTabBarItem(
+                label: 'Home',
+                customIcon: CupertinoIcons.house,
+                activeCustomIcon: CupertinoIcons.house_fill,
+              ),
+              CNTabBarItem(
+                label: 'Settings',
+                customIcon: CupertinoIcons.settings,
+              ),
+            ],
+            currentIndex: 0,
+            onTap: (_) {},
           ),
         ),
       );
       await tester.pump();
 
-      // Selected tab uses the active icon
-      final activeHome = tester.widget<Icon>(iconWith(Icons.home));
+      // Selected tab renders the active icon
+      final activeHome = tester.widget<Icon>(
+        iconWith(CupertinoIcons.house_fill),
+      );
       expect(activeHome.size, 28.0);
 
       await drainPlatformViewGuard(tester);
@@ -844,22 +858,23 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        MaterialApp(
-          home: Scaffold(
-            body: CNTabBar(
-              items: const [
-                CNTabBarItem(label: 'Home', customIcon: Icons.home),
-                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
-              ],
-              currentIndex: 0,
-              onTap: (_) {},
-            ),
+        hostTabBar(
+          CNTabBar(
+            items: const [
+              CNTabBarItem(label: 'Home', customIcon: CupertinoIcons.house),
+              CNTabBarItem(
+                label: 'Settings',
+                customIcon: CupertinoIcons.settings,
+              ),
+            ],
+            currentIndex: 0,
+            onTap: (_) {},
           ),
         ),
       );
       await tester.pump();
 
-      final homeIcon = tester.widget<Icon>(iconWith(Icons.home));
+      final homeIcon = tester.widget<Icon>(iconWith(CupertinoIcons.house));
       expect(homeIcon.size, 25.0);
 
       await drainPlatformViewGuard(tester);

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -762,4 +762,107 @@ void main() {
       expect(item.activeCustomIcon, Icons.home_filled);
     });
   });
+
+  group('CNTabBar iconSize', () {
+    // These tests exercise the Flutter fallback path (which is what runs
+    // in `flutter test` since UiKitView/AppKitView aren't available off-
+    // device). The fallback mirrors the native sizing precedence used in
+    // `_prepareCreationParams`, so it's the right place to assert that
+    // bar-level `iconSize` is honored across icon kinds — including the
+    // previously-broken `customIcon` path (Issue: customIcon ignored
+    // bar-level iconSize, was hardcoded to 25.0).
+    Finder iconWith(IconData data) =>
+        find.byWidgetPredicate((w) => w is Icon && w.icon == data);
+
+    // Drains `PlatformViewGuard`'s 500ms debug-mode debounce so the test
+    // doesn't fail with a "pending Timer after dispose" error when run in
+    // isolation. The guard is scheduled in `_CNTabBarState.initState`.
+    Future<void> drainPlatformViewGuard(WidgetTester tester) async {
+      await tester.pump(const Duration(milliseconds: 600));
+    }
+
+    testWidgets('bar-level iconSize sizes customIcon (unselected)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CNTabBar(
+              iconSize: 32.0,
+              items: const [
+                CNTabBarItem(label: 'Home', customIcon: Icons.home),
+                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
+              ],
+              currentIndex: 0,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final homeIcon = tester.widget<Icon>(iconWith(Icons.home));
+      final settingsIcon = tester.widget<Icon>(iconWith(Icons.settings));
+      expect(homeIcon.size, 32.0);
+      expect(settingsIcon.size, 32.0);
+
+      await drainPlatformViewGuard(tester);
+    });
+
+    testWidgets('bar-level iconSize sizes activeCustomIcon (selected)', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CNTabBar(
+              iconSize: 28.0,
+              items: const [
+                CNTabBarItem(
+                  label: 'Home',
+                  customIcon: Icons.home_outlined,
+                  activeCustomIcon: Icons.home,
+                ),
+                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
+              ],
+              currentIndex: 0,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      // Selected tab uses the active icon
+      final activeHome = tester.widget<Icon>(iconWith(Icons.home));
+      expect(activeHome.size, 28.0);
+
+      await drainPlatformViewGuard(tester);
+    });
+
+    testWidgets('customIcon falls back to 25pt when iconSize unset', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CNTabBar(
+              items: const [
+                CNTabBarItem(label: 'Home', customIcon: Icons.home),
+                CNTabBarItem(label: 'Settings', customIcon: Icons.settings),
+              ],
+              currentIndex: 0,
+              onTap: (_) {},
+            ),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      final homeIcon = tester.widget<Icon>(iconWith(Icons.home));
+      expect(homeIcon.size, 25.0);
+
+      await drainPlatformViewGuard(tester);
+    });
+  });
 }


### PR DESCRIPTION
Setting `iconSize` on a `CNTabBar` was silently ignored for tabs that use `customIcon` (_any `IconData` like `CupertinoIcons.house` or `Icons.home`)_. 

It worked for `SF Symbols` and `imageAsset` items, but custom icons were always rendered at a hard-coded 25 pt. 

This **PR** makes `iconSize` actually do what it says for every kind of tab item.