### PR TITLE
fix: render CNSwitch as a switch on macOS (not a checkbox)

### DIFF
--- a/macos/cupertino_native_better/Sources/cupertino_native_better/Shared/SwitchShared.swift
+++ b/macos/cupertino_native_better/Sources/cupertino_native_better/Shared/SwitchShared.swift
@@ -8,6 +8,9 @@ struct CupertinoSwitchView: View {
   var body: some View {
     let base = Toggle("", isOn: $model.value)
       .labelsHidden()
+      // On macOS a default Toggle renders as a checkbox; force the switch
+      // style so CNSwitch is a real toggle (iOS already defaults to a switch).
+      .toggleStyle(.switch)
       .disabled(!model.enabled)
       .onChange(of: model.value) { newValue in
         model.onChange(newValue)


### PR DESCRIPTION
### Problem

On macOS, `CNSwitch` renders as a **checkbox** instead of a switch/toggle.

The cause is SwiftUI: a `Toggle` without an explicit toggle style defaults to a **checkbox** on macOS (this is especially visible when building against the macOS 26 / Xcode 26 SDK). `CupertinoSwitchView` (macOS `Shared/SwitchShared.swift`) builds a bare `Toggle` with no style, so it picks up that default.

### Fix

Apply `.toggleStyle(.switch)` to the macOS `Toggle` so it renders as the native switch. `.switch` is available macOS 11.0+ (the package's minimum), so no availability guard is needed.

- **iOS is unaffected** — it already defaults to a switch; this change only touches the macOS shared view.
- One line; no API or behavior change beyond the corrected appearance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)