### PR TITLE
fix: LiquidGlassContainer glass renders short when its frame reaches into the bottom safe area

### DIFF
--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
@@ -67,6 +67,13 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
     self.hostingController = UIHostingController(rootView: glassView)
     self.hostingController.view.backgroundColor = .clear
     self.hostingController.overrideUserInterfaceStyle = isDark ? .dark : .light
+    // Don't propagate the screen's safe area into the SwiftUI glass. When the
+    // container's frame reaches into the bottom safe area (e.g. a floating
+    // bottom panel), UIHostingController otherwise insets the SwiftUI content
+    // by the overlap, so the glass renders short of the frame's bottom edge.
+    // Same issue class as the safeAreaInsets override in
+    // CupertinoSwitchPlatformView.swift.
+    self.hostingController.safeAreaRegions = []
 
     super.init()
     self.configuredShape = shape


### PR DESCRIPTION
## Problem

When a `LiquidGlassContainer` is positioned so that its frame reaches into the **bottom safe area** (e.g. a floating bottom panel on a home-indicator device), the glass effect renders **short of the platform view's bottom edge**. On an iPhone 17 Pro (iOS 26.4 simulator) the glass ends up to **22 pt** above the frame it was given — the container's Flutter box is correct, but the visible glass stops at the safe-area line.

## Root cause

`LiquidGlassContainerPlatformView` embeds the SwiftUI glass in a `UIHostingController`. `UIHostingController` propagates the screen's safe area into its SwiftUI content, so the hosted `GeometryReader`/shape gets inset by the overlap between the view's frame and the unsafe region. The `GeometryReader` then reports the reduced size and the glass shape fills only that.

This never shows for capsules/buttons floating *above* the safe area — it only appears once a container's frame intersects it, which is exactly the floating-bottom-panel case.

## Fix

Disable safe-area propagation on the hosting controller:

```swift
self.hostingController.safeAreaRegions = []
```

`safeAreaRegions` is iOS 16.4+; the class is `@available(iOS 26.0, *)`, so no availability guard is needed.

This matches the intent of the existing workaround for the same issue class in `CupertinoSwitchPlatformView.swift` (the `safeAreaInsets → .zero` override added there).

## Repro

1. Place a `LiquidGlassContainer(config: LiquidGlassConfig(shape: .rect, cornerRadius: 40), ...)` in a `Stack` → `Positioned(left: 12, right: 12, top: 0, bottom: 0)` inside a bottom-anchored box whose bottom edge sits 12 pt above the screen bottom (inside the 34 pt home-indicator inset).
2. Observe: the glass's bottom edge renders at the safe-area line (~34 pt), not at the frame's bottom (12 pt). Content drawn by Flutter over the container is unaffected — only the native glass is short, so children visually stick out of the glass.
3. With this fix, the glass fills the full frame (verified by pixel-measuring screenshots: side and bottom margins identical before/after at 13.0/13.0/13.0 pt).

Happy to adjust if you'd prefer the swizzle approach used for the switch instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)