### PR TITLE
feat: template-ify image assets without explicit color so Liquid Glass tints them

### DIFF
--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoButtonPlatformView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoButtonPlatformView.swift
@@ -139,6 +139,11 @@ class CupertinoButtonPlatformView: NSObject, FlutterPlatformView {
           finalImage = ImageUtils.scaleImage(finalImage!, to: targetSize, scale: iconScale)
         }
       }
+      // No explicit color: render as a template so the control's tint — and
+      // Liquid Glass's automatic foreground adaptation — applies.
+      if finalImage != nil, iconColor == nil {
+        finalImage = finalImage!.withRenderingMode(.alwaysTemplate)
+      }
     } else if let data = imageData {
       let format = imageFormat
       let iconColorARGB: Int? = iconColor != nil ? ImageUtils.colorToARGB(iconColor!) : nil
@@ -155,6 +160,11 @@ class CupertinoButtonPlatformView: NSObject, FlutterPlatformView {
       } else {
         let size: CGSize? = iconSize != nil ? CGSize(width: iconSize!, height: iconSize!) : nil
         finalImage = ImageUtils.createImageFromData(data, format: format, size: size, scale: iconScale)
+      }
+      // No explicit color: render as a template so the control's tint — and
+      // Liquid Glass's automatic foreground adaptation — applies.
+      if finalImage != nil, iconColor == nil {
+        finalImage = finalImage!.withRenderingMode(.alwaysTemplate)
       }
     }
     
@@ -462,6 +472,12 @@ class CupertinoButtonPlatformView: NSObject, FlutterPlatformView {
             image = UIImage(data: customIconBytes.data, scale: UIScreen.main.scale)?.withRenderingMode(.alwaysTemplate)
           } else if let name = args["buttonIconName"] as? String {
             image = UIImage(systemName: name)
+          }
+          
+          // No explicit color: render as a template so the control's tint — and
+          // Liquid Glass's automatic foreground adaptation — applies.
+          if let img = image, (args["buttonIconColor"] as? NSNumber) == nil {
+            image = img.withRenderingMode(.alwaysTemplate)
           }
           
           // Apply size and styling if image was found

--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoPopupMenuButtonPlatformView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoPopupMenuButtonPlatformView.swift
@@ -402,7 +402,8 @@ class CupertinoPopupMenuButtonPlatformView: NSObject, FlutterPlatformView {
             )
           } else {
             let size = CGSize(width: iconSize ?? 18, height: iconSize ?? 18)
-            image = ImageUtils.loadFlutterAsset(assetPath, size: size, format: format, scale: self.iconScale)
+            image = ImageUtils.loadFlutterAsset(assetPath, size: size, format: format, scale: self.iconScale)?
+              .withRenderingMode(.alwaysTemplate)
           }
         } else if i < self.imageAssetData.count, let data = self.imageAssetData[i] {
           let format = i < self.imageAssetFormats.count ? self.imageAssetFormats[i] : nil
@@ -430,7 +431,8 @@ class CupertinoPopupMenuButtonPlatformView: NSObject, FlutterPlatformView {
             )
           } else {
             let size: CGSize? = iconSize != nil ? CGSize(width: iconSize!, height: iconSize!) : nil
-            image = ImageUtils.createImageFromData(data, format: format, size: size, scale: self.iconScale)
+            image = ImageUtils.createImageFromData(data, format: format, size: size, scale: self.iconScale)?
+              .withRenderingMode(.alwaysTemplate)
           }
         }
         

--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/GlassButtonSwiftUI.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/GlassButtonSwiftUI.swift
@@ -28,9 +28,11 @@ struct GlassButtonSwiftUI: View {
   /// own `Button(action:)` for per-button hit-testing.
   var applyOwnGlass: Bool = true
 
-  /// Computes the effective icon color
+  /// Computes the effective icon color. An explicit per-icon color wins over
+  /// the control tint; when neither is provided the system/glass default
+  /// (automatic adaptive foreground) applies.
   private var effectiveIconColor: Color? {
-    return tint ?? iconColor
+    return iconColor ?? tint
   }
 
   var body: some View {

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -302,8 +302,16 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
 
   bool get _isDark => ThemeHelper.isDark(context);
 
-  Color? get _effectiveTint =>
-      widget.tint ?? ThemeHelper.getPrimaryColor(context);
+  /// Regular glass resolves its content foreground from the material's
+  /// automatic appearance, so no accent fallback is applied. Other styles
+  /// keep the primary fallback.
+  Color? get _effectiveTint {
+    final tint = widget.tint;
+    if (tint != null || widget.config.style != CNButtonStyle.glass) {
+      return tint ?? ThemeHelper.getPrimaryColor(context);
+    }
+    return null;
+  }
 
   @override
   void dispose() {
@@ -1491,7 +1499,8 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
         return _effectiveTint;
       case CNButtonStyle.glass:
         // For iOS < 26, approximate glass with tinted appearance
-        return _effectiveTint?.withValues(alpha: 0.1);
+        return (_effectiveTint ?? Theme.of(context).primaryColor)
+            .withValues(alpha: 0.1);
       default:
         return null;
     }

--- a/lib/components/popup_menu_button.dart
+++ b/lib/components/popup_menu_button.dart
@@ -221,8 +221,15 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
   Animation<double>? _secondaryRouteAnim;
 
   bool get _isDark => ThemeHelper.isDark(context);
-  Color? get _effectiveTint =>
-      widget.tint ?? ThemeHelper.getPrimaryColor(context);
+  // Regular glass resolves its content foreground from the material's
+  // automatic appearance, so no accent fallback is applied for it.
+  Color? get _effectiveTint {
+    final tint = widget.tint;
+    if (tint != null || widget.buttonStyle != CNButtonStyle.glass) {
+      return tint ?? ThemeHelper.getPrimaryColor(context);
+    }
+    return null;
+  }
 
   @override
   void didUpdateWidget(covariant CNPopupMenuButton oldWidget) {


### PR DESCRIPTION
## Problem

When an `imageAsset` (PNG/SVG via `CNImageAsset`) is supplied **without an explicit color**, it renders with its baked colors as a non-template image. On iOS 26 Liquid Glass buttons, the glass material resolves its appearance from the backdrop (dark image behind → dark glass, even in light mode), and the system automatically adapts template/vibrant foreground content to stay legible. Non-template assets never enter that path, so a black-baked glyph becomes invisible on dark glass and a white-baked one on light glass. This also forces callers to pin a color from Dart, which is often wrong.

`customIcon` (IconData) already gets `.alwaysTemplate` natively — the same treatment is missing for `imageAsset` bytes/paths.

## Change

- **`CupertinoButtonPlatformView.swift`** — when `iconColor == nil`, render the loaded/created image with `.withRenderingMode(.alwaysTemplate)` (init and `setButtonIcon` paths), so the control's tint — and Liquid Glass's automatic foreground adaptation — applies. Explicit colors keep the existing baked-tint behavior.
- **`CupertinoPopupMenuButtonPlatformView.swift`** — same treatment for menu-item image assets (menus color template images automatically).
- **`GlassButtonSwiftUI.swift`** — `effectiveIconColor` now prefers the per-icon `iconColor` over the control `tint`; when both are nil the system/glass default (automatic adaptive foreground) applies.
- **`button.dart` / `popup_menu_button.dart`** — `_effectiveTint` no longer forces the primary-color fallback for the regular `glass` style (Dart always sent a concrete tint, defeating `.label`/automatic resolution). `prominentGlass` keeps the accent fallback since its material is tinted by design. The <26 Flutter fallback look for glass is preserved via `Theme.of(context).primaryColor` alpha.

## Why not `GlassButtonGroupView`?

`CNGlassButtonGroup` renders through `GlassButtonSwiftUI`, which applies `.renderingMode(.template)` on its `Image(uiImage:)` at draw time — so UIImage-level templating is redundant for the group. The `effectiveIconColor` ordering change and the Dart `_effectiveTint` de-pin are sufficient: the group's icons resolve to the glass automatic foreground when no explicit color is passed. The UIKit-only views (button, popup) are the ones that need the UIImage-level `.withRenderingMode(.alwaysTemplate)` because they set `cfg.image` directly without a draw-time template override.

## Impact

- Glass buttons with uncolored image assets now adapt their foreground to the glass material's resolved dark/light appearance (matching SF Symbol behavior).
- Existing explicit colors (`imageAsset.color`, `CNButton.tint`, `labelColor`) are unchanged in behavior.
- Glass-style controls without an explicit tint shift from app-primary-tinted content to the system's automatic/dynamic label color.

Verified: `flutter analyze` clean; iOS simulator build succeeds.