### PR TITLE
fix: supersample customIcon rendering to eliminate pixelation on thin strokes

### DIFF
--- a/lib/utils/icon_renderer.dart
+++ b/lib/utils/icon_renderer.dart
@@ -164,13 +164,16 @@ Future<Uint8List?> iconDataToImageBytes(
     final double pixelRatio =
         ui.PlatformDispatcher.instance.views.first.devicePixelRatio;
 
+    const double supersample = 2.0;
+    final double canvasScale = pixelRatio * supersample;
+
     final TextPainter painter = TextPainter(
       text: TextSpan(
         text: String.fromCharCode(iconData.codePoint),
         style: TextStyle(
           inherit: false,
           color: color,
-          fontSize: size,
+          fontSize: size * supersample,
           fontFamily: iconData.fontFamily,
           package: iconData.fontPackage,
         ),
@@ -178,14 +181,14 @@ Future<Uint8List?> iconDataToImageBytes(
       textDirection: TextDirection.ltr,
     )..layout();
 
-    final double padding = size;
+    final double padding = size * supersample;
     final double logicalWidth = painter.width + padding * 2;
     final double logicalHeight = painter.height + padding * 2;
-    final int paddedPixelWidth = (logicalWidth * pixelRatio).ceil();
-    final int paddedPixelHeight = (logicalHeight * pixelRatio).ceil();
+    final int paddedPixelWidth = (logicalWidth * canvasScale).ceil();
+    final int paddedPixelHeight = (logicalHeight * canvasScale).ceil();
 
     final ui.PictureRecorder recorder = ui.PictureRecorder();
-    final Canvas canvas = Canvas(recorder)..scale(pixelRatio);
+    final Canvas canvas = Canvas(recorder)..scale(canvasScale);
     painter.paint(canvas, Offset(padding, padding));
     final ui.Image paddedImage = await recorder.endRecording().toImage(
       paddedPixelWidth,
@@ -255,7 +258,7 @@ Future<Uint8List?> iconDataToImageBytes(
         glyphPixelHeight,
       ),
       Rect.fromLTWH(dstX, dstY, drawnWidth, drawnHeight),
-      Paint(),
+      Paint()..filterQuality = FilterQuality.high,
     );
     final ui.Image squareImage = await squareRecorder.endRecording().toImage(
       outputPixelSize,


### PR DESCRIPTION
## Problem

`iconDataToImageBytes` renders the glyph at 1× `fontSize`, then the "scaled to fill" re-blit **upscales** the cropped glyph (font em-box padding makes the ink smaller than the requested `size`) using `Paint()` — which defaults to `FilterQuality.none` (nearest-neighbour). Thin strokes (chevrons, outlines, plus signs) get visible jaggies.

This affects **every** `customIcon` (IconData) path in the package — `CNButton`, `CNPopupMenuButton`, `CNTabBar`, `CNIcon`, `CNGlassButtonGroup` — since they all route through this function (9 call sites).

## Fix

Two changes in `lib/utils/icon_renderer.dart`:

1. **Supersample**: render the TextPainter at `fontSize: size * 2.0` into a canvas scaled at `pixelRatio * 2.0` (2× in each dimension = 4× total pixel count). The glyph now has sub-pixel detail that 1× rendering can't capture.

2. **High-quality downscale**: change `Paint()` to `Paint()..filterQuality = FilterQuality.high` on the re-blit. The blit changes from an **upscale** (1.1×, nearest-neighbour → jaggies) to a **downscale** (2:1 per axis, bilinear+mipmap → crisp, anti-aliased edges).

Output dimensions are unchanged (`size × pixelRatio`). The 4× larger intermediate buffer is disposed immediately after the downsample.

## Context

This refines the "scaled to fill" step from the recent `iconDataToImageBytes` rewrite (v1.5.x changelog). That rewrite fixed correctness — matching SF Symbol's "pointSize is ink size" convention — but the `Paint()` default left a rendering quality regression on the upscale. This PR keeps the ink-size matching intact and fixes the quality.

## Impact

No API change. All 9 call sites get crisper rendering for free. Results are cached per (icon, size, pixelRatio) so the supersample cost is paid once per unique icon.

Verified: `flutter analyze` clean.