### PR TITLE
fix: LiquidGlassContainer ignores config.effect — honour it and add CNGlassEffect.clear

### DIFF
--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
@@ -248,8 +248,8 @@ struct LiquidGlassContainerSwiftUI: View {
   }
   
   private func glassEffectForConfig() -> Glass {
-    // Always use .regular for now - prominent glass API may be available in future
-    var glass = Glass.regular
+    // `prominent` still has no SwiftUI counterpart, so it keeps falling back to regular.
+    var glass: Glass = effect == "clear" ? .clear : .regular
     
     if let tintColor = tint {
       glass = glass.tint(Color(tintColor))

--- a/lib/style/glass_effect.dart
+++ b/lib/style/glass_effect.dart
@@ -9,6 +9,10 @@ enum CNGlassEffect {
 
   /// Prominent glass effect with enhanced visual prominence.
   prominent,
+
+  /// Clear glass effect — far more transparent than [regular], for glass that sits over
+  /// imagery and should let it through rather than frosting it.
+  clear,
 }
 
 /// Shapes for Liquid Glass effects.

--- a/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
+++ b/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
@@ -136,7 +136,8 @@ struct LiquidGlassContainerSwiftUI: View {
   }
 
   private func glassEffectForConfig() -> Glass {
-    var glass = Glass.regular
+    // `prominent` still has no SwiftUI counterpart, so it keeps falling back to regular.
+    var glass: Glass = effect == "clear" ? .clear : .regular
     if let tintColor = tint { glass = glass.tint(Color(tintColor)) }
     if interactive { glass = glass.interactive() }
     return glass


### PR DESCRIPTION
## Problem

`LiquidGlassConfig` takes an `effect` (`CNGlassEffect.regular` / `.prominent`), and the value is
serialised over the channel as `'effect': config.effect.name` — but the native side never reads it.
Both `glassEffectForConfig()` implementations open with:

```swift
// Always use .regular for now - prominent glass API may be available in future
var glass = Glass.regular
```

So the parameter is accepted, sent, and then silently discarded. Separately, SwiftUI's `Glass` has a
third variant — `.clear` — which the plugin has no way to reach at all.

`.clear` matters for glass placed over imagery. `.regular` frosts the content behind it; `.clear`
lets it through, which is what Apple's own media controls use. Today the only way to get it is to
fork the plugin, which is why we ended up doing exactly that.

## Root cause

`glassEffectForConfig()` ignores its `effect` input on both platforms:

- `ios/.../Views/LiquidGlassContainerView.swift`
- `macos/.../Views/LiquidGlassContainerNSView.swift`

## Fix

Add the enum variant, and let the container honour the value it is already being given:

```swift
// before
var glass = Glass.regular

// after
// `prominent` still has no SwiftUI counterpart, so it keeps falling back to regular.
var glass: Glass = effect == "clear" ? .clear : .regular
```

**`.prominent` behaviour is unchanged** — it still falls back to `.regular`, exactly as the old
comment described. Nothing shifts for existing users; `regular` and `prominent` both keep rendering
as they do today, and only the new `clear` value takes a different path.

3 files, +8/−3. `flutter analyze` clean on `lib`.

## Repro

1. Put a `LiquidGlassContainer` with `CNGlassEffectShape.circle` over a photo.
2. Build with `effect: CNGlassEffect.regular`, then with `effect: CNGlassEffect.prominent` — the two
   render identically, confirming `effect` is not reaching the native side.
3. With this change, `effect: CNGlassEffect.clear` renders visibly transparent against the same
   photo, while `regular` and `prominent` stay as before.

Verified on an iOS 26 simulator via the example app.

## Notes

Happy to add a `pr##_glass_clear_test.dart` demo page under `example/lib/demos` to match the
existing `pr64_` / `pr66_` pages if you'd like it in the same PR — left out for now to keep the diff
to the fix itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
