### PR TITLE
fix: glass keeps its old size when the platform view is resized

### DIFF
--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
@@ -2,9 +2,29 @@ import Flutter
 import UIKit
 import SwiftUI
 
+/// SwiftUI sizes the glass from a `GeometryReader`, which does not re-run when UIKit alone attaches or
+/// resizes the view, so the host reports both and the glass is re-rendered.
+private final class CNGlassHostView: UIView {
+  var onNeedsGlassRefresh: (() -> Void)?
+  private var lastSize: CGSize = .zero
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+    guard window != nil else { return }
+    onNeedsGlassRefresh?()
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    guard bounds.size != lastSize else { return }
+    lastSize = bounds.size
+    onNeedsGlassRefresh?()
+  }
+}
+
 @available(iOS 26.0, *)
 class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
-  private let container: UIView
+  private let container: CNGlassHostView
   private var hostingController: UIHostingController<LiquidGlassContainerSwiftUI>
   private let channel: FlutterMethodChannel
 
@@ -18,7 +38,7 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
 
   init(frame: CGRect, viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "CupertinoNativeLiquidGlassContainer_\(viewId)", binaryMessenger: messenger)
-    self.container = UIView(frame: frame)
+    self.container = CNGlassHostView(frame: frame)
     self.container.backgroundColor = .clear
     
     // Parse arguments
@@ -93,7 +113,10 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       hostingController.view.trailingAnchor.constraint(equalTo: container.trailingAnchor),
       hostingController.view.bottomAnchor.constraint(equalTo: container.bottomAnchor),
     ])
-    
+
+    container.onNeedsGlassRefresh = { [weak self] in self?.refreshGlass() }
+    DispatchQueue.main.async { [weak self] in self?.refreshGlass() }
+
     // Set up method channel handler
     channel.setMethodCallHandler { [weak self] (call, result) in
       if call.method == "updateConfig" {
@@ -205,6 +228,11 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
     self.configuredCornerRadius = cornerRadius
   }
   
+  private func refreshGlass() {
+    hostingController.rootView = hostingController.rootView
+    hostingController.view.setNeedsLayout()
+  }
+
   func view() -> UIView {
     return container
   }

--- a/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
+++ b/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
@@ -6,6 +6,7 @@ import SwiftUI
 class LiquidGlassContainerNSView: NSView {
   private var hostingController: NSHostingController<LiquidGlassContainerSwiftUI>
   private let channel: FlutterMethodChannel
+  private var lastSize: CGSize = .zero
 
   init(viewId: Int64, args: Any?, messenger: FlutterBinaryMessenger) {
     self.channel = FlutterMethodChannel(name: "CupertinoNativeLiquidGlassContainer_\(viewId)", binaryMessenger: messenger)
@@ -77,6 +78,26 @@ class LiquidGlassContainerNSView: NSView {
 
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidMoveToWindow() {
+    super.viewDidMoveToWindow()
+    guard window != nil else { return }
+    refreshGlass()
+  }
+
+  override func layout() {
+    super.layout()
+    guard bounds.size != lastSize else { return }
+    lastSize = bounds.size
+    refreshGlass()
+  }
+
+  /// SwiftUI sizes the glass from a `GeometryReader`, which does not re-run when AppKit alone
+  /// attaches or resizes the view, so re-render it when either happens.
+  private func refreshGlass() {
+    hostingController.rootView = hostingController.rootView
+    hostingController.view.needsLayout = true
   }
 
   private func updateConfig(args: Any?) {


### PR DESCRIPTION
## Problem

`LiquidGlassContainerSwiftUI` sizes itself from a `GeometryReader`:

```swift
GeometryReader { geometry in
  shapeForConfig()
    .glassEffect(glassEffectForConfig(), in: shapeForConfig())
    .frame(width: geometry.size.width, height: geometry.size.height)
}
```

That only re-evaluates when SwiftUI re-renders the hosted view. Attaching or resizing the platform
view from UIKit does neither, so once the container's size changes after creation the glass keeps
drawing at the old size — a visibly squashed or undersized shape inside a correctly sized box.

It shows up wherever the container is long-lived and resized rather than rebuilt. In our case a
full-screen player page is kept mounted while collapsed and moved with a transform, so its glass view
is created once and lives through every collapse and expand while its box changes underneath it. The
first layout after creation is enough on its own: the view is created at zero size, laid out at its
real size a moment later, and nothing re-renders the glass in between.

## Impact

The only way out from Dart is to force a rebuild by changing the widget's key, which disposes the
`UiKitView` and creates a new one. That teardown is visible as a flash. So consumers get to choose
between a mis-sized glass shape and a flash, and we spent a while trading one for the other before
finding this.

## Fix

Report attach and real size changes from the host view, and re-render on both:

```swift
private final class CNGlassHostView: UIView {
  var onNeedsGlassRefresh: (() -> Void)?
  private var lastSize: CGSize = .zero

  override func didMoveToWindow() {
    super.didMoveToWindow()
    guard window != nil else { return }
    onNeedsGlassRefresh?()
  }

  override func layoutSubviews() {
    super.layoutSubviews()
    guard bounds.size != lastSize else { return }
    lastSize = bounds.size
    onNeedsGlassRefresh?()
  }
}
```

```swift
private func refreshGlass() {
  hostingController.rootView = hostingController.rootView
  hostingController.view.setNeedsLayout()
}
```

Re-assigning `rootView` is enough to make SwiftUI re-measure, and it is the same mechanism
`updateConfig` already relies on — nothing is torn down, so there is no flash. The `lastSize` guard
keeps this to genuine size changes rather than every layout pass.

The same change is applied to macOS using `layout()` and `viewDidMoveToWindow()`.

## Verification

Tested in an app that previously needed the Dart-side workaround. With every workaround removed the
glass renders at the correct size on first appearance, through the collapse/expand transition, and on
repeated runs — with no flash, since nothing is recreated. Confirmed by our QA on iOS 26 across the
app's other glass surfaces too (tab bar, sheets, buttons), which the change also affects.

2 files, +52/−3. `flutter analyze` clean on `lib`.

macOS is untested here — the change mirrors the iOS one using AppKit's equivalents, so it is worth a
look from someone who can run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
