### PR TITLE
fix(tab-bar): give the bar a Liquid Glass background on iOS 26

### DIFF
--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoTabBarPlatformView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/CupertinoTabBarPlatformView.swift
@@ -1065,11 +1065,22 @@ channel.setMethodCallHandler { [weak self] call, result in
 
   // MARK: - Appearance helpers
 
-  /// Builds a UITabBarAppearance with transparent background and optional custom label font.
+  /// Builds a UITabBarAppearance for the bar, plus the optional custom label font.
+  ///
+  /// On iOS 26+ the bar takes the default background, which is what makes UIKit
+  /// give it the Liquid Glass material. A transparent background there is not
+  /// "glass with no tint" — it is *no material at all*: the bar becomes a hole,
+  /// and whatever is behind it shows through at full sharpness. Below iOS 26
+  /// the default background is an opaque chrome bar, which is not what this
+  /// widget is for, so those keep the transparent appearance.
   @available(iOS 13.0, *)
   private func makeAppearance() -> UITabBarAppearance {
     let ap = UITabBarAppearance()
-    ap.configureWithTransparentBackground()
+    if #available(iOS 26.0, *) {
+      ap.configureWithDefaultBackground()
+    } else {
+      ap.configureWithTransparentBackground()
+    }
     ap.shadowColor = .clear
     ap.shadowImage = UIImage()
     applyLabelFont(to: ap)


### PR DESCRIPTION
## The problem

`makeAppearance()` configures the tab bar's `UITabBarAppearance` with `configureWithTransparentBackground()` on every iOS version.

On iOS 26 that isn't "glass without a tint" — it means the bar has **no background material at all**. The bar becomes a see-through hole, and whatever is behind it renders through at full sharpness. The only genuinely glassy thing left is the selection pill, because iOS draws that itself.

It's most obvious in a Flutter app, where everything behind the platform view is Flutter-rendered content: list rows and body copy read straight through the bar, right across the tab labels. At large Dynamic Type sizes a whole paragraph runs through them.

## The change

One line, guarded by version:

```swift
if #available(iOS 26.0, *) {
  ap.configureWithDefaultBackground()   // Liquid Glass
} else {
  ap.configureWithTransparentBackground()
}
```

iOS 26+ takes the default background, which is what makes UIKit apply the Liquid Glass material. Earlier versions keep the transparent appearance, because their default background is an opaque chrome bar — not what this widget is for. `shadowColor`/`shadowImage` clearing is untouched, so the bar still has no hairline.

## Measurements

iPhone 17 simulator, iOS 26.5, a scrolling list behind the bar. Mean gradient energy inside the bar band, normalised against the same content just above the bar — this shows whether what's behind is actually being attenuated:

| appearance | above bar | through bar | retained |
|---|---|---|---|
| `configureWithTransparentBackground` | 7.79 | 10.63 | **136%** |
| `configureWithDefaultBackground` | 13.65 | 8.25 | **60%** |

136% is over 100% because the bar's own glyphs and capsule stroke contribute edges inside that band — they still do in the second row, which is why 60% understates the blur.

Visually: text passing under the bar goes from fully legible to a soft smear, and the bar's separation from the page in light mode rises from 1.26:1 to 1.50:1.

## Notes

- Only `CupertinoTabBarPlatformView.makeAppearance()` is touched; no API change, no Dart change.
- The existing simulator caveat in the file (software rasterizer positions the selection pill differently from Metal hardware) still applies to pill placement, but the missing background is a source-level fact independent of it.
- Happy to gate it behind an opt-in parameter instead if you'd rather not change the default — say the word and I'll rework it.
