### PR TITLE
Reduce redundant native channel updates and fix pop transition completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Arrivo fork — transition performance
+
+- Notify native containment on animation status changes instead of every frame.
+- Keep glass transition handling active until the outgoing pop animation ends.
+- Add channel-traffic and pop-duration regression tests.
+
 ## 1.6.0
 
 > Minor rather than patch because `CNGlassEffect` gains a value (`clear`). That is source-breaking for anyone with an exhaustive `switch` over the enum. 1.5.5 was tagged during development and never published; everything it contained is here.

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -261,6 +261,7 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
 
   MethodChannel? _channel;
   bool? _lastIsDark;
+  bool? _lastEnabled;
   int? _lastTint;
   String? _lastTitle;
   String? _lastIconName;
@@ -728,6 +729,7 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
     _intrinsicHeight = null;
     _lastTint = resolveColorToArgb(_effectiveTint, context);
     _lastIsDark = _isDark;
+    _lastEnabled = widget.enabled && widget.onPressed != null;
     _lastTitle = widget.label;
     _lastIconName = widget.icon?.name;
     _lastIconSize = widget.icon?.size;
@@ -812,10 +814,18 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
       });
       _lastStyle = widget.config.style;
     }
-    // Enabled state
-    await ch.invokeMethod('setEnabled', {
-      'enabled': (widget.enabled && widget.onPressed != null),
-    });
+    final enabled = widget.enabled && widget.onPressed != null;
+    if (_lastEnabled != enabled) {
+      _lastEnabled = enabled;
+      try {
+        await ch.invokeMethod('setEnabled', {'enabled': enabled});
+      } catch (_) {
+        if (identical(ch, _channel) && _lastEnabled == enabled) {
+          _lastEnabled = null;
+        }
+        rethrow;
+      }
+    }
     if (_lastTitle != widget.label && widget.label != null) {
       await ch.invokeMethod('setButtonTitle', {'title': widget.label});
       _lastTitle = widget.label;

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -315,7 +315,7 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     _channel?.setMethodCallHandler(null);
     super.dispose();
@@ -339,13 +339,13 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() {
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) {
     final anim = _secondaryRouteAnim;
     if (anim == null) return;
     final isAnimating =

--- a/lib/components/button.dart
+++ b/lib/components/button.dart
@@ -749,8 +749,8 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
         ? resolveColorToArgb(widget.config.labelColor!, context)
         : null;
     _lastLabelFontWeight = widget.config.labelFontWeight?.value;
-    // Always request intrinsic size to get both width and height
-    // Use a small delay to ensure native view has finished layout
+    // Fixed horizontal icon buttons never consume intrinsic dimensions.
+    if (!_usesIntrinsicSize) return;
     Future.delayed(const Duration(milliseconds: 10), () {
       if (mounted && _channel != null) {
         _requestIntrinsicSize();
@@ -771,14 +771,22 @@ class _CNButtonState extends State<CNButton> with ModalHideMixin<CNButton> {
     return null;
   }
 
+  bool get _usesIntrinsicSize =>
+      !widget.isIcon ||
+      widget.label != null ||
+      widget.config.imagePlacement == CNImagePlacement.top ||
+      widget.config.imagePlacement == CNImagePlacement.bottom;
+
   Future<void> _requestIntrinsicSize() async {
     final ch = _channel;
-    if (ch == null) return;
+    if (ch == null || !_usesIntrinsicSize) return;
     try {
       final size = await ch.invokeMethod<Map>('getIntrinsicSize');
       final w = (size?['width'] as num?)?.toDouble();
       final h = (size?['height'] as num?)?.toDouble();
-      if (mounted) {
+      if (!mounted || !identical(ch, _channel)) return;
+      if ((w != null && w != _intrinsicWidth) ||
+          (h != null && h != _intrinsicHeight)) {
         setState(() {
           if (w != null) _intrinsicWidth = w;
           if (h != null) _intrinsicHeight = h;

--- a/lib/components/floating_island.dart
+++ b/lib/components/floating_island.dart
@@ -236,13 +236,14 @@ class _CNFloatingIslandState extends State<CNFloatingIsland>
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() => _pushContainmentIfNeeded();
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) =>
+      _pushContainmentIfNeeded();
 
   void _pushContainmentIfNeeded() {
     final anim = _secondaryRouteAnim;
@@ -278,7 +279,7 @@ class _CNFloatingIslandState extends State<CNFloatingIsland>
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     _animationController.dispose();
     _controller._detach();

--- a/lib/components/glass_button_group.dart
+++ b/lib/components/glass_button_group.dart
@@ -152,7 +152,7 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup>
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     super.dispose();
   }
@@ -161,13 +161,14 @@ class _CNGlassButtonGroupState extends State<CNGlassButtonGroup>
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() => _pushContainmentIfNeeded();
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) =>
+      _pushContainmentIfNeeded();
 
   void _pushContainmentIfNeeded() {
     final anim = _secondaryRouteAnim;

--- a/lib/components/liquid_glass_container.dart
+++ b/lib/components/liquid_glass_container.dart
@@ -87,7 +87,7 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer>
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     PlatformViewGuard.readyNotifier.removeListener(_onPlatformViewGuardReady);
     _channel?.setMethodCallHandler(null);
@@ -99,13 +99,14 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer>
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() => _pushContainmentIfNeeded();
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) =>
+      _pushContainmentIfNeeded();
 
   void _pushContainmentIfNeeded() {
     final anim = _secondaryRouteAnim;

--- a/lib/components/popup_menu_button.dart
+++ b/lib/components/popup_menu_button.dart
@@ -204,6 +204,7 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
 
   MethodChannel? _channel;
   bool? _lastIsDark;
+  Map<String, Object?>? _lastItems;
   int? _lastTint;
   String? _lastTitle;
   String? _lastIconName;
@@ -744,6 +745,7 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
     _lastIconSize = widget.buttonIcon?.size;
     _lastIconColor = resolveColorToArgb(widget.buttonIcon?.color, context);
     _lastStyle = widget.buttonStyle;
+    _lastItems = _menuItems();
     if (!widget.isIconButton) {
       _requestIntrinsicSize();
     }
@@ -773,76 +775,7 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
   Future<void> _syncPropsToNativeIfNeeded() async {
     final ch = _channel;
     if (ch == null) return;
-    // Prepare popup items upfront to avoid using BuildContext after awaits.
-    final updLabels = <String>[];
-    final updSymbols = <String>[];
-    final updIsDivider = <bool>[];
-    final updEnabled = <bool>[];
-    final updChecked = <bool>[];
-    final updIsDestructive = <bool>[];
-    final updSizes = <double?>[];
-    final updColors = <int?>[];
-    final updModes = <String?>[];
-    final updPalettes = <List<int?>?>[];
-    final updGradients = <bool?>[];
-    final updImageAssetPaths = <String>[];
-    final updImageAssetData = <Uint8List?>[];
-    final updImageAssetFormats = <String>[];
-    for (final e in widget.items) {
-      if (e is CNPopupMenuDivider) {
-        updLabels.add('');
-        updSymbols.add('');
-        updIsDivider.add(true);
-        updEnabled.add(false);
-        updChecked.add(false);
-        updIsDestructive.add(false);
-        updSizes.add(null);
-        updColors.add(null);
-        updModes.add(null);
-        updPalettes.add(null);
-        updGradients.add(null);
-        updImageAssetPaths.add('');
-        updImageAssetData.add(null);
-        updImageAssetFormats.add('');
-      } else if (e is CNPopupMenuItem) {
-        updLabels.add(e.label);
-        updSymbols.add(e.icon?.name ?? '');
-        updIsDivider.add(false);
-        updEnabled.add(e.enabled);
-        updChecked.add(e.checked);
-        updIsDestructive.add(e.isDestructive);
-        updSizes.add(e.imageAsset?.size ?? e.icon?.size);
-        updColors.add(
-          resolveColorToArgb(e.imageAsset?.color ?? e.icon?.color, context),
-        );
-        updModes.add(e.imageAsset?.mode?.name ?? e.icon?.mode?.name);
-        updPalettes.add(
-          e.icon?.paletteColors
-              ?.map((c) => resolveColorToArgb(c, context))
-              .toList(),
-        );
-        updGradients.add(e.imageAsset?.gradient ?? e.icon?.gradient);
-
-        // Handle imageAsset for menu items
-        if (e.imageAsset != null) {
-          updImageAssetPaths.add(e.imageAsset!.assetPath);
-          updImageAssetData.add(e.imageAsset!.imageData);
-          // Auto-detect format if not provided
-          updImageAssetFormats.add(
-            e.imageAsset!.imageFormat ??
-                detectImageFormat(
-                  e.imageAsset!.assetPath,
-                  e.imageAsset!.imageData,
-                ) ??
-                '',
-          );
-        } else {
-          updImageAssetPaths.add('');
-          updImageAssetData.add(null);
-          updImageAssetFormats.add('');
-        }
-      }
-    }
+    final items = _menuItems();
     // Capture context-dependent values before any awaits
     final tint = resolveColorToArgb(_effectiveTint, context);
     final preIconName = widget.buttonIcon?.name;
@@ -934,7 +867,91 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
       }
     }
 
-    await ch.invokeMethod('setItems', {
+    if (!_menuValuesEqual(_lastItems, items)) {
+      _lastItems = items;
+      try {
+        await ch.invokeMethod('setItems', items);
+      } catch (_) {
+        if (identical(ch, _channel) && identical(_lastItems, items)) {
+          _lastItems = null;
+        }
+        rethrow;
+      }
+    }
+  }
+
+  Map<String, Object?> _menuItems() {
+    // Prepare popup items upfront to avoid using BuildContext after awaits.
+    final updLabels = <String>[];
+    final updSymbols = <String>[];
+    final updIsDivider = <bool>[];
+    final updEnabled = <bool>[];
+    final updChecked = <bool>[];
+    final updIsDestructive = <bool>[];
+    final updSizes = <double?>[];
+    final updColors = <int?>[];
+    final updModes = <String?>[];
+    final updPalettes = <List<int?>?>[];
+    final updGradients = <bool?>[];
+    final updImageAssetPaths = <String>[];
+    final updImageAssetData = <Uint8List?>[];
+    final updImageAssetFormats = <String>[];
+    for (final e in widget.items) {
+      if (e is CNPopupMenuDivider) {
+        updLabels.add('');
+        updSymbols.add('');
+        updIsDivider.add(true);
+        updEnabled.add(false);
+        updChecked.add(false);
+        updIsDestructive.add(false);
+        updSizes.add(null);
+        updColors.add(null);
+        updModes.add(null);
+        updPalettes.add(null);
+        updGradients.add(null);
+        updImageAssetPaths.add('');
+        updImageAssetData.add(null);
+        updImageAssetFormats.add('');
+      } else if (e is CNPopupMenuItem) {
+        updLabels.add(e.label);
+        updSymbols.add(e.icon?.name ?? '');
+        updIsDivider.add(false);
+        updEnabled.add(e.enabled);
+        updChecked.add(e.checked);
+        updIsDestructive.add(e.isDestructive);
+        updSizes.add(e.imageAsset?.size ?? e.icon?.size);
+        updColors.add(
+          resolveColorToArgb(e.imageAsset?.color ?? e.icon?.color, context),
+        );
+        updModes.add(e.imageAsset?.mode?.name ?? e.icon?.mode?.name);
+        updPalettes.add(
+          e.icon?.paletteColors
+              ?.map((c) => resolveColorToArgb(c, context))
+              .toList(),
+        );
+        updGradients.add(e.imageAsset?.gradient ?? e.icon?.gradient);
+
+        // Handle imageAsset for menu items
+        if (e.imageAsset != null) {
+          updImageAssetPaths.add(e.imageAsset!.assetPath);
+          updImageAssetData.add(e.imageAsset!.imageData);
+          // Auto-detect format if not provided
+          updImageAssetFormats.add(
+            e.imageAsset!.imageFormat ??
+                detectImageFormat(
+                  e.imageAsset!.assetPath,
+                  e.imageAsset!.imageData,
+                ) ??
+                '',
+          );
+        } else {
+          updImageAssetPaths.add('');
+          updImageAssetData.add(null);
+          updImageAssetFormats.add('');
+        }
+      }
+    }
+    return {
       'labels': updLabels,
       'sfSymbols': updSymbols,
       'isDivider': updIsDivider,
@@ -949,7 +966,7 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
       'imageAssetPaths': updImageAssetPaths,
       'imageAssetData': updImageAssetData,
       'imageAssetFormats': updImageAssetFormats,
-    });
+    };
   }
 
   Future<void> _syncBrightnessIfNeeded() async {
@@ -1031,4 +1048,22 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
       ),
     );
   }
+}
+
+bool _menuValuesEqual(Object? a, Object? b) {
+  if (identical(a, b)) return true;
+  if (a is List && b is List) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (!_menuValuesEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (a is Map && b is Map) {
+    return a.length == b.length &&
+        a.keys.every(
+          (key) => b.containsKey(key) && _menuValuesEqual(a[key], b[key]),
+        );
+  }
+  return a == b;
 }

--- a/lib/components/popup_menu_button.dart
+++ b/lib/components/popup_menu_button.dart
@@ -246,7 +246,7 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     _channel?.setMethodCallHandler(null);
     super.dispose();
@@ -256,13 +256,13 @@ class _CNPopupMenuButtonState extends State<CNPopupMenuButton>
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() {
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) {
     _pushContainmentIfNeeded();
   }
 

--- a/lib/components/search_bar.dart
+++ b/lib/components/search_bar.dart
@@ -254,7 +254,7 @@ class _CNSearchBarState extends State<CNSearchBar>
 
   @override
   void dispose() {
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = null;
     CNTabBarRouteObserver.anyModalDepth.removeListener(_onAnyModalDepthChanged);
     _animationController.dispose();
@@ -268,13 +268,14 @@ class _CNSearchBarState extends State<CNSearchBar>
     final route = ModalRoute.of(context);
     final newAnim = route?.secondaryAnimation;
     if (identical(newAnim, _secondaryRouteAnim)) return;
-    _secondaryRouteAnim?.removeListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.removeStatusListener(_onSecondaryRouteAnimChanged);
     _secondaryRouteAnim = newAnim;
-    _secondaryRouteAnim?.addListener(_onSecondaryRouteAnimChanged);
+    _secondaryRouteAnim?.addStatusListener(_onSecondaryRouteAnimChanged);
     _onSecondaryRouteAnimChanged();
   }
 
-  void _onSecondaryRouteAnimChanged() => _pushContainmentIfNeeded();
+  void _onSecondaryRouteAnimChanged([AnimationStatus? status]) =>
+      _pushContainmentIfNeeded();
 
   // Legacy modal-up trigger disabled: ModalHideMixin (maybeHiddenPlaceholder +
   // native setInteractive) is the supported modern path for modal hiding.

--- a/lib/utils/transition_observer.dart
+++ b/lib/utils/transition_observer.dart
@@ -45,7 +45,8 @@ class CNTransitionObserver extends NavigatorObserver {
   @override
   void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
     _beginTransition();
-    _scheduleEndTransition(previousRoute);
+    // The outgoing route owns the reverse animation.
+    _scheduleEndTransition(route);
   }
 
   @override

--- a/test/transition_channel_test.dart
+++ b/test/transition_channel_test.dart
@@ -1,0 +1,101 @@
+import 'package:cupertino_native_better/cupertino_native_better.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'containment changes at transition boundaries, not every frame',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      final messenger = tester.binding.defaultBinaryMessenger;
+      final calls = <String, List<bool>>{};
+      messenger.setMockMethodCallHandler(SystemChannels.platform_views, (
+        call,
+      ) async {
+        if (call.method == 'create') {
+          final args = call.arguments as Map;
+          final viewType = args['viewType'] as String;
+          final channel = '${viewType}_${args['id']}';
+          calls[channel] = [];
+          messenger.setMockMethodCallHandler(MethodChannel(channel), (
+            call,
+          ) async {
+            if (call.method == 'setTransitioning') {
+              calls[channel]!.add((call.arguments as Map)['active'] as bool);
+            }
+            if (call.method == 'getIntrinsicSize') {
+              return {'width': 44.0, 'height': 44.0};
+            }
+            return null;
+          });
+        }
+        return null;
+      });
+      addTearDown(() {
+        messenger.setMockMethodCallHandler(SystemChannels.platform_views, null);
+        for (final channel in calls.keys) {
+          messenger.setMockMethodCallHandler(MethodChannel(channel), null);
+        }
+      });
+      PlatformViewGuard.ensureScheduled();
+      await tester.pump(const Duration(milliseconds: 500));
+      final navigatorKey = GlobalKey<NavigatorState>();
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: Scaffold(
+            body: Column(
+              children: [
+                CNButton(onPressed: () {}, label: 'Open'),
+                const LiquidGlassContainer(
+                  config: LiquidGlassConfig(cornerRadius: 16),
+                  child: SizedBox(width: 100, height: 40),
+                ),
+                CNPopupMenuButton.icon(
+                  buttonIcon: const CNSymbol('ellipsis'),
+                  items: const [CNPopupMenuItem(label: 'Item')],
+                  onSelected: (_) {},
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(calls.length, 3);
+      final hostChannels = calls.keys.toList();
+      for (final values in calls.values) {
+        values.clear();
+      }
+      navigatorKey.currentState!.push(
+        CupertinoPageRoute<void>(
+          builder: (_) => const Scaffold(body: Text('Details')),
+        ),
+      );
+      await tester.pump();
+      for (var frame = 0; frame < 40; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      for (final channel in hostChannels) {
+        expect(calls[channel], [true, false], reason: channel);
+        calls[channel]!.clear();
+      }
+      navigatorKey.currentState!.pop();
+      await tester.pump();
+      for (var frame = 0; frame < 40; frame++) {
+        await tester.pump(const Duration(milliseconds: 16));
+      }
+      for (final channel in hostChannels) {
+        expect(calls[channel], [true, false], reason: channel);
+      }
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+      debugDefaultTargetPlatformOverride = null;
+    },
+    skip: !PlatformVersion.supportsLiquidGlass,
+  );
+}

--- a/test/transition_observer_test.dart
+++ b/test/transition_observer_test.dart
@@ -1,0 +1,47 @@
+import 'package:cupertino_native_better/utils/transition_observer.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('glass stays contained until the outgoing pop animation ends', (
+    tester,
+  ) async {
+    final calls = <String>[];
+    const channel = MethodChannel('cupertino_native');
+    tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(channel, (
+      call,
+    ) async {
+      calls.add(call.method);
+      return null;
+    });
+    addTearDown(
+      () => tester.binding.defaultBinaryMessenger.setMockMethodCallHandler(
+        channel,
+        null,
+      ),
+    );
+    final navigatorKey = GlobalKey<NavigatorState>();
+    await tester.pumpWidget(
+      MaterialApp(
+        navigatorKey: navigatorKey,
+        navigatorObservers: [CNTransitionObserver()],
+        home: const Scaffold(),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 500));
+    navigatorKey.currentState!.push(
+      CupertinoPageRoute<void>(builder: (_) => const Scaffold()),
+    );
+    await tester.pumpAndSettle();
+    calls.clear();
+
+    navigatorKey.currentState!.pop();
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 400));
+    expect(calls, ['beginTransition']);
+    await tester.pumpAndSettle();
+    expect(calls, ['beginTransition', 'endTransition']);
+  });
+}

--- a/test/unchanged_native_props_test.dart
+++ b/test/unchanged_native_props_test.dart
@@ -55,6 +55,21 @@ void main() {
                     enabled: enabled,
                     onPressed: hasCallback ? () {} : null,
                   ),
+                  CNButton.icon(
+                    key: const ValueKey('fixedIcon'),
+                    icon: const CNSymbol('chevron.left'),
+                    config: const CNButtonConfig(width: 32, minHeight: 32),
+                    onPressed: () {},
+                  ),
+                  CNButton(
+                    key: const ValueKey('verticalIcon'),
+                    label: 'Above',
+                    icon: const CNSymbol('arrow.up'),
+                    config: const CNButtonConfig(
+                      imagePlacement: CNImagePlacement.top,
+                    ),
+                    onPressed: () {},
+                  ),
                   CNPopupMenuButton.icon(
                     buttonIcon: const CNSymbol('ellipsis'),
                     items: [
@@ -86,7 +101,12 @@ void main() {
       }
 
       await rebuild();
-      expect(calls.length, 2);
+      expect(calls.length, 4);
+      expect(sent('getIntrinsicSize').length, 2);
+      expect(
+        tester.getSize(find.byKey(const ValueKey('fixedIcon'))),
+        const Size(32, 32),
+      );
       clear();
       for (var i = 0; i < 10; i++) {
         await rebuild();

--- a/test/unchanged_native_props_test.dart
+++ b/test/unchanged_native_props_test.dart
@@ -1,0 +1,133 @@
+import 'package:cupertino_native_better/cupertino_native_better.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets(
+    'unchanged rebuilds do not resend button and menu state',
+    (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.iOS;
+      addTearDown(() => debugDefaultTargetPlatformOverride = null);
+      final messenger = tester.binding.defaultBinaryMessenger;
+      final calls = <String, List<MethodCall>>{};
+      messenger.setMockMethodCallHandler(SystemChannels.platform_views, (
+        call,
+      ) async {
+        if (call.method == 'create') {
+          final args = call.arguments as Map;
+          final channel = '${args['viewType']}_${args['id']}';
+          calls[channel] = [];
+          messenger.setMockMethodCallHandler(MethodChannel(channel), (
+            call,
+          ) async {
+            calls[channel]!.add(call);
+            if (call.method == 'getIntrinsicSize') {
+              return {'width': 44.0, 'height': 44.0};
+            }
+            return null;
+          });
+        }
+        return null;
+      });
+      addTearDown(() {
+        messenger.setMockMethodCallHandler(SystemChannels.platform_views, null);
+        for (final channel in calls.keys) {
+          messenger.setMockMethodCallHandler(MethodChannel(channel), null);
+        }
+      });
+      PlatformViewGuard.ensureScheduled();
+      await tester.pump(const Duration(milliseconds: 500));
+
+      var enabled = true;
+      var hasCallback = true;
+      var checked = false;
+      var destructive = false;
+      Future<void> rebuild() async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Column(
+                children: [
+                  CNButton(
+                    label: 'Refresh',
+                    enabled: enabled,
+                    onPressed: hasCallback ? () {} : null,
+                  ),
+                  CNPopupMenuButton.icon(
+                    buttonIcon: const CNSymbol('ellipsis'),
+                    items: [
+                      CNPopupMenuItem(
+                        label: 'Item',
+                        checked: checked,
+                        enabled: enabled,
+                        isDestructive: destructive,
+                      ),
+                    ],
+                    onSelected: (_) {},
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      }
+
+      List<MethodCall> sent(String method) => calls.values
+          .expand((values) => values)
+          .where((call) => call.method == method)
+          .toList();
+      void clear() {
+        for (final values in calls.values) {
+          values.clear();
+        }
+      }
+
+      await rebuild();
+      expect(calls.length, 2);
+      clear();
+      for (var i = 0; i < 10; i++) {
+        await rebuild();
+      }
+      expect(
+        {
+          'setEnabled': sent('setEnabled').length,
+          'setItems': sent('setItems').length,
+        },
+        {'setEnabled': 0, 'setItems': 0},
+      );
+
+      enabled = false;
+      checked = true;
+      destructive = true;
+      await rebuild();
+      expect(sent('setEnabled').single.arguments, {'enabled': false});
+      final menu = sent('setItems').single.arguments as Map;
+      expect(menu['enabled'], [false]);
+      expect(menu['checked'], [true]);
+      expect(menu['isDestructive'], [true]);
+      clear();
+      await rebuild();
+      expect(sent('setEnabled'), isEmpty);
+      expect(sent('setItems'), isEmpty);
+
+      enabled = true;
+      await rebuild();
+      expect(sent('setEnabled').single.arguments, {'enabled': true});
+      clear();
+      hasCallback = false;
+      await rebuild();
+      expect(sent('setEnabled').single.arguments, {'enabled': false});
+      clear();
+      hasCallback = true;
+      await rebuild();
+      expect(sent('setEnabled').single.arguments, {'enabled': true});
+      await tester.pumpWidget(const SizedBox.shrink());
+      await tester.pumpAndSettle();
+      debugDefaultTargetPlatformOverride = null;
+    },
+    skip: !PlatformVersion.supportsLiquidGlass,
+  );
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -31,7 +31,8 @@ void main() {
       );
 
       await tester.pump();
-      await tester.pump(const Duration(milliseconds: 350));
+      // Settle the debug-only platform-view startup guard.
+      await tester.pump(const Duration(milliseconds: 500));
 
       // Flutter fallback should show the text field
       expect(find.byType(CupertinoTextField), findsOneWidget);


### PR DESCRIPTION
During Cupertino route push/pop animations, six native controls send `setTransitioning` on every secondary-animation frame even though their containment logic only depends on `AnimationStatus`. This repeatedly reapplies native layer containment on the main thread. Observe status changes instead, retaining the existing initial and platform-view-creation synchronization.

The affected controls are `CNButton`, `CNFloatingIsland`, `CNGlassButtonGroup`, `LiquidGlassContainer`, `CNPopupMenuButton`, and `CNSearchBar`. There are no public API or Swift rendering changes.

The optional `CNTransitionObserver` also ended pop transitions against the previous route, whose primary animation is already complete. Track the outgoing route so transition handling lasts until its reverse animation finishes.

Unrelated widget rebuilds also resent `CNButton.setEnabled` and rebuilt popup menus through `setItems`, even when their native state was unchanged. Cache the effective enabled state (including callback availability) and compare resolved menu payloads by value, including nested palettes and image bytes. Real changes still propagate; failed sends invalidate the cached state so a later rebuild can retry.

### Evidence

Reproduced in my app on an iPhone 17 simulator running iOS 26.5, Flutter 3.44.3 / Dart 3.12.2. After application-only cleanup, a warm Settings → About → Settings sequence still sent 103 `setTransitioning` calls. With this patch, the equivalent sequence sent 9 calls, with the same 2 native views created and disposed. These are debug-simulator observations, not release performance benchmarks.

The final audit also measured 5 redundant `setEnabled` calls on a warm Settings → About → Settings round trip with the initial fork, and 0 after the state deduplication. The final bounded trace still creates/disposes exactly 2 views and sends 9 containment notifications. Simulator frame timings remain diagnostic, not a claim of universally jank-free rendering.

### Regression coverage and validation

- A native-platform-view channel test pumps push and pop one frame at a time and asserts exactly `[true, false]` per transition for button, glass container, and popup menu containment. It skips platforms without native glass support.
- An observer test verifies that a 500 ms pop has not sent `endTransition` at 400 ms and does send it when the animation finishes.
- Both new tests were run against the original upstream implementations and failed; both pass with this patch.
- Adjusted the existing widget smoke test's startup wait to cover the platform-view guard timer rather than leaving a pending timer.
- A rebuild regression test creates fresh, equivalent button/menu widgets ten times and checks that no enabled/menu updates are sent. It then checks disable/re-enable, callback removal/restoration, checked items, and destructive items. The unchanged-rebuild assertion fails against the pre-optimization fork and passes with the fix.
- `flutter test`: 116 tests passed on macOS.
- `flutter analyze`: no issues.
