### PR TITLE
feat: shape one glass effect as several disjoint parts

### DIFF
--- a/example/lib/demos/pr73_liquid_glass_parts_test.dart
+++ b/example/lib/demos/pr73_liquid_glass_parts_test.dart
@@ -1,0 +1,240 @@
+import 'package:cupertino_native_better/cupertino_native_better.dart';
+import 'package:flutter/cupertino.dart';
+
+/// PR #73 verification — `LiquidGlassConfig.parts`: one glass effect shaped as several disjoint
+/// rounded rects.
+///
+/// PR: https://github.com/gunumdogdu/cupertino_native_better/pull/73
+/// Reported by @johndavid92.
+///
+/// ### The problem this solves
+///
+/// A bar of two glass pills — a wide one and a lone circle beside it — can be built two ways today,
+/// and both are wrong in a different way.
+///
+///  * **A container per pill.** Each is its own platform view with its own `.glassEffect`, so each
+///    samples its own backdrop. Over uneven content the two settle on visibly different shades: on
+///    the reporter's nav bar they measured **44/255** apart. Both pills do keep their rim.
+///  * **One container, clipped in Flutter.** A single rect of glass with the two pills cut out of it
+///    with `ClipPath`. One effect means one sample, so the shades match — but `glassEffect(_:in:)`
+///    draws its rim on *the shape it was handed*, which is the rect. The clip then hides almost all
+///    of it. On the reporter's bar the circle kept a rim from 270° round to 90° — the half that
+///    happens to lie on the rect's own right edge — and had none from 105° to 255°.
+///
+/// So the choice was matching colour or a complete rim, never both.
+///
+/// ### The fix
+///
+/// `Shape` is free to return a path with more than one subpath, and `glassEffect(_:in:)` accepts any
+/// `Shape`. So `parts` builds one `Path` holding a rounded rect per part and hands that to a single
+/// `.glassEffect`. One effect — one sample, so the parts cannot drift apart — and the rim follows
+/// every part's own outline, because that is what the path is.
+///
+/// ### How this screen proves it
+///
+/// The backdrop is deliberately uneven: a dark block under the left of the bar and a light one under
+/// the right, so the wide pill and the circle sit over different content. That is the case that makes
+/// two containers disagree.
+///
+/// The **magenta outlines are drawn in Flutter** on the same rects the glass is given. Flutter always
+/// lays those out correctly, so they mark where each pill truly is.
+///
+/// Switch between the three modes and watch the circle's **left** edge, the side facing the wide pill:
+///
+///  * `parts` — shades match **and** the circle is rimmed all the way round.
+///  * `clipped` — shades match, but the circle's left side has no rim: it is interior to the rect the
+///    effect was given.
+///  * `two views` — the circle is rimmed all the way round, but its shade no longer matches the wide
+///    pill's.
+class Pr73LiquidGlassPartsTestPage extends StatefulWidget {
+  const Pr73LiquidGlassPartsTestPage({super.key});
+
+  @override
+  State<Pr73LiquidGlassPartsTestPage> createState() => _Pr73LiquidGlassPartsTestPageState();
+}
+
+enum _Mode { parts, clipped, twoViews }
+
+class _Pr73LiquidGlassPartsTestPageState extends State<Pr73LiquidGlassPartsTestPage> {
+  static const double _barHeight = 64;
+  static const double _gap = 10;
+  static const double _circle = 64;
+
+  _Mode _mode = _Mode.parts;
+
+  @override
+  Widget build(BuildContext context) {
+    return CupertinoPageScaffold(
+      navigationBar: const CupertinoNavigationBar(middle: Text('PR #73: LiquidGlass parts')),
+      child: SafeArea(
+        child: Column(
+          children: <Widget>[
+            Padding(
+              padding: const EdgeInsets.all(16),
+              child: CupertinoSegmentedControl<_Mode>(
+                groupValue: _mode,
+                onValueChanged: (_Mode value) => setState(() => _mode = value),
+                children: const <_Mode, Widget>{
+                  _Mode.parts: Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Text('parts')),
+                  _Mode.clipped: Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Text('clipped')),
+                  _Mode.twoViews: Padding(padding: EdgeInsets.symmetric(horizontal: 10), child: Text('two views')),
+                },
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Text(
+                _blurb,
+                style: const TextStyle(fontSize: 13, color: CupertinoColors.secondaryLabel),
+              ),
+            ),
+            Expanded(
+              child: Center(
+                child: Stack(
+                  children: <Widget>[
+                    // Dark under the wide pill, light under the circle: the split that makes two
+                    // separate effects disagree.
+                    Positioned.fill(
+                      child: Row(
+                        children: const <Widget>[
+                          Expanded(flex: 3, child: ColoredBox(color: Color(0xFF1B2430))),
+                          Expanded(flex: 2, child: ColoredBox(color: Color(0xFFF2EDE4))),
+                        ],
+                      ),
+                    ),
+                    Center(
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: SizedBox(height: _barHeight, child: LayoutBuilder(builder: _buildBar)),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String get _blurb {
+    switch (_mode) {
+      case _Mode.parts:
+        return 'One effect, shaped as both pills. Expect matching shades and a rim all the way round '
+            'the circle.';
+      case _Mode.clipped:
+        return 'One rect of glass, pills cut out with ClipPath. Shades match, but the circle has no '
+            'rim on its left side.';
+      case _Mode.twoViews:
+        return 'A container per pill. Each is rimmed, but the shades no longer match.';
+    }
+  }
+
+  Widget _buildBar(BuildContext context, BoxConstraints constraints) {
+    final double wide = constraints.maxWidth - _circle - _gap;
+    final List<CNGlassPart> parts = <CNGlassPart>[
+      CNGlassPart(left: 0, top: 0, width: wide, height: _barHeight, radius: _barHeight / 2),
+      CNGlassPart(left: wide + _gap, top: 0, width: _circle, height: _barHeight, radius: _barHeight / 2),
+    ];
+
+    return Stack(
+      children: <Widget>[
+        if (_mode == _Mode.parts)
+          Positioned.fill(
+            child: LiquidGlassContainer(
+              config: LiquidGlassConfig(effect: CNGlassEffect.regular, parts: parts),
+              child: const SizedBox.expand(),
+            ),
+          ),
+        if (_mode == _Mode.clipped)
+          Positioned.fill(
+            child: ClipPath(
+              clipper: _PartsClipper(parts),
+              child: const LiquidGlassContainer(
+                config: LiquidGlassConfig(effect: CNGlassEffect.regular, shape: CNGlassEffectShape.rect),
+                child: SizedBox.expand(),
+              ),
+            ),
+          ),
+        if (_mode == _Mode.twoViews)
+          Row(
+            children: <Widget>[
+              SizedBox(
+                width: wide,
+                child: const LiquidGlassContainer(
+                  config: LiquidGlassConfig(effect: CNGlassEffect.regular),
+                  child: SizedBox.expand(),
+                ),
+              ),
+              const SizedBox(width: _gap),
+              SizedBox(
+                width: _circle,
+                child: const LiquidGlassContainer(
+                  config: LiquidGlassConfig(effect: CNGlassEffect.regular),
+                  child: SizedBox.expand(),
+                ),
+              ),
+            ],
+          ),
+        // Flutter-drawn markers on the same rects the glass is given.
+        Positioned.fill(child: IgnorePointer(child: CustomPaint(painter: _PartsOutline(parts)))),
+      ],
+    );
+  }
+}
+
+class _PartsClipper extends CustomClipper<Path> {
+  const _PartsClipper(this.parts);
+
+  final List<CNGlassPart> parts;
+
+  @override
+  Path getClip(Size size) {
+    final Path path = Path();
+    for (final CNGlassPart part in parts) {
+      path.addRRect(
+        RRect.fromLTRBR(
+          part.left,
+          part.top,
+          part.left + part.width,
+          part.top + part.height,
+          Radius.circular(part.radius),
+        ),
+      );
+    }
+    return path;
+  }
+
+  @override
+  bool shouldReclip(_PartsClipper oldClipper) => oldClipper.parts != parts;
+}
+
+class _PartsOutline extends CustomPainter {
+  const _PartsOutline(this.parts);
+
+  final List<CNGlassPart> parts;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1
+      ..color = const Color(0xFFFF00AA);
+    for (final CNGlassPart part in parts) {
+      canvas.drawRRect(
+        RRect.fromLTRBR(
+          part.left,
+          part.top,
+          part.left + part.width,
+          part.top + part.height,
+          Radius.circular(part.radius),
+        ),
+        paint,
+      );
+    }
+  }
+
+  @override
+  bool shouldRepaint(_PartsOutline oldDelegate) => oldDelegate.parts != parts;
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,6 +32,7 @@ import 'demos/pr64_liquid_glass_safe_area_test.dart';
 import 'demos/pr66_glass_image_asset_tint_test.dart';
 import 'demos/pr67_icon_supersample_test.dart';
 import 'demos/pr69_glass_effect_test.dart';
+import 'demos/pr73_liquid_glass_parts_test.dart';
 import 'demos/issue55_popup_menu_destructive_test.dart';
 import 'demos/pr42_tabbar_iconsize_customicon_test.dart';
 import 'demos/issue33_svg_tabbar_test.dart';
@@ -491,6 +492,20 @@ class HomePage extends StatelessWidget {
                   Navigator.of(context).push(
                     CupertinoPageRoute(
                       builder: (_) => const Pr69GlassEffectTestPage(),
+                    ),
+                  );
+                },
+              ),
+              CupertinoListTile(
+                title: Text('PR #73: LiquidGlass parts'),
+                leading: CNIcon(
+                  symbol: CNSymbol('capsule.on.rectangle', color: accentColor),
+                ),
+                trailing: CupertinoListTileChevron(),
+                onTap: () {
+                  Navigator.of(context).push(
+                    CupertinoPageRoute(
+                      builder: (_) => const Pr73LiquidGlassPartsTestPage(),
                     ),
                   );
                 },

--- a/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
+++ b/ios/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerView.swift
@@ -28,6 +28,7 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
     var tint: UIColor? = nil
     var interactive: Bool = false
     var isDark: Bool = false
+    var parts: [CNGlassPart] = []
     
     if let dict = args as? [String: Any] {
       if let effectStr = dict["effect"] as? String {
@@ -53,6 +54,7 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       if let isDarkBool = dict["isDark"] as? Bool {
         isDark = isDarkBool
       }
+      parts = CNGlassPart.list(from: dict["parts"])
     }
     
     // Create SwiftUI view
@@ -61,7 +63,8 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       shape: shape,
       cornerRadius: cornerRadius,
       tint: tint,
-      interactive: interactive
+      interactive: interactive,
+      parts: parts
     )
 
     self.hostingController = UIHostingController(rootView: glassView)
@@ -195,7 +198,8 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
       shape: shape,
       cornerRadius: cornerRadius,
       tint: tint,
-      interactive: interactive
+      interactive: interactive,
+      parts: CNGlassPart.list(from: dict["parts"])
     )
 
     hostingController.rootView = newGlassView
@@ -216,6 +220,52 @@ class LiquidGlassContainerPlatformView: NSObject, FlutterPlatformView {
   }
 }
 
+/// One rounded rectangle of a multi-part glass shape, in points relative to the container's top-left.
+struct CNGlassPart: Equatable {
+  let left: CGFloat
+  let top: CGFloat
+  let width: CGFloat
+  let height: CGFloat
+  let radius: CGFloat
+
+  var rect: CGRect { CGRect(x: left, y: top, width: width, height: height) }
+
+  /// Never rounder than a capsule of that part, so a full-radius square reads as a circle.
+  var clampedRadius: CGFloat { min(radius, min(width, height) / 2.0) }
+
+  static func list(from raw: Any?) -> [CNGlassPart] {
+    guard let entries = raw as? [[String: Any]] else { return [] }
+    return entries.compactMap { entry in
+      guard let left = entry["left"] as? CGFloat,
+            let top = entry["top"] as? CGFloat,
+            let width = entry["width"] as? CGFloat,
+            let height = entry["height"] as? CGFloat,
+            let radius = entry["radius"] as? CGFloat,
+            width > 0, height > 0
+      else { return nil }
+      return CNGlassPart(left: left, top: top, width: width, height: height, radius: radius)
+    }
+  }
+}
+
+/// The parts as one `Shape`. `glassEffect(_:in:)` rims whatever outline it is handed, so a path of
+/// disjoint parts is rimmed on each of them while staying a single effect — one backdrop sample, so
+/// the parts cannot drift apart in colour.
+struct CNGlassPartsShape: Shape, Equatable {
+  let parts: [CNGlassPart]
+
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    for part in parts {
+      path.addRoundedRect(
+        in: part.rect,
+        cornerSize: CGSize(width: part.clampedRadius, height: part.clampedRadius)
+      )
+    }
+    return path
+  }
+}
+
 @available(iOS 26.0, *)
 struct LiquidGlassContainerSwiftUI: View {
   let effect: String
@@ -223,6 +273,7 @@ struct LiquidGlassContainerSwiftUI: View {
   let cornerRadius: CGFloat?
   let tint: UIColor?
   let interactive: Bool
+  let parts: [CNGlassPart]
 
   /// Observe transition state to disable glass effect during navigation
   @ObservedObject private var transitionObserver = CNTransitionObserver.shared
@@ -263,6 +314,9 @@ struct LiquidGlassContainerSwiftUI: View {
   }
   
   private func shapeForConfig() -> some Shape {
+    if !parts.isEmpty {
+      return AnyShape(CNGlassPartsShape(parts: parts))
+    }
     switch shape {
     case "rect":
       if let radius = cornerRadius {

--- a/lib/components/liquid_glass_container.dart
+++ b/lib/components/liquid_glass_container.dart
@@ -172,6 +172,10 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer>
         'tint': resolveColorToArgb(widget.config.tint!, context),
       'interactive': widget.config.interactive,
       'isDark': ThemeHelper.isDark(context),
+      if (widget.config.parts != null)
+        'parts': widget.config.parts!
+            .map((CNGlassPart part) => part.toMap())
+            .toList(),
     };
 
     final platformView = defaultTargetPlatform == TargetPlatform.iOS
@@ -232,6 +236,10 @@ class _LiquidGlassContainerState extends State<LiquidGlassContainer>
           'tint': resolveColorToArgb(widget.config.tint!, context),
         'interactive': widget.config.interactive,
         'isDark': _isDark,
+        if (widget.config.parts != null)
+          'parts': widget.config.parts!
+              .map((CNGlassPart part) => part.toMap())
+              .toList(),
       });
     } catch (e) {
       // Ignore errors - view might not be ready yet

--- a/lib/style/glass_effect.dart
+++ b/lib/style/glass_effect.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart' show listEquals;
 import 'package:flutter/widgets.dart';
 import '../utils/version_detector.dart';
 import '../components/liquid_glass_container.dart';
@@ -42,6 +43,57 @@ enum CNGlassEffectShape {
   circle,
 }
 
+/// One rounded rectangle of a multi-part glass shape, in logical points relative to the container's
+/// own top-left. A square with `radius` at half its side is a circle.
+@immutable
+class CNGlassPart {
+  /// Creates one part of a multi-part glass shape.
+  const CNGlassPart({
+    required this.left,
+    required this.top,
+    required this.width,
+    required this.height,
+    required this.radius,
+  });
+
+  /// Offset from the container's left edge.
+  final double left;
+
+  /// Offset from the container's top edge.
+  final double top;
+
+  /// Part width.
+  final double width;
+
+  /// Part height.
+  final double height;
+
+  /// Corner radius, clamped natively to half the shorter side.
+  final double radius;
+
+  /// Wire format for the platform channel.
+  Map<String, double> toMap() => <String, double>{
+    'left': left,
+    'top': top,
+    'width': width,
+    'height': height,
+    'radius': radius,
+  };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is CNGlassPart &&
+          left == other.left &&
+          top == other.top &&
+          width == other.width &&
+          height == other.height &&
+          radius == other.radius;
+
+  @override
+  int get hashCode => Object.hash(left, top, width, height, radius);
+}
+
 /// Configuration for Liquid Glass effects.
 class LiquidGlassConfig {
   /// The glass effect variant to apply.
@@ -59,6 +111,12 @@ class LiquidGlassConfig {
   /// Whether the glass effect should be interactive (responds to touch/pointer).
   final bool interactive;
 
+  /// Renders one glass effect whose shape is these disjoint parts, overriding [shape]. One effect
+  /// means one backdrop sample, so the parts cannot drift apart in colour, and the rim follows every
+  /// part's own outline — unlike clipping a single-shape container, which rims only the shape it was
+  /// given. Null (the default) keeps the [shape] behaviour.
+  final List<CNGlassPart>? parts;
+
   /// Creates a configuration for Liquid Glass effects.
   const LiquidGlassConfig({
     this.effect = CNGlassEffect.regular,
@@ -66,6 +124,7 @@ class LiquidGlassConfig {
     this.cornerRadius,
     this.tint,
     this.interactive = false,
+    this.parts,
   });
 
   @override
@@ -77,7 +136,8 @@ class LiquidGlassConfig {
           shape == other.shape &&
           cornerRadius == other.cornerRadius &&
           tint == other.tint &&
-          interactive == other.interactive;
+          interactive == other.interactive &&
+          listEquals(parts, other.parts);
 
   @override
   int get hashCode =>
@@ -85,7 +145,8 @@ class LiquidGlassConfig {
       shape.hashCode ^
       (cornerRadius?.hashCode ?? 0) ^
       (tint?.hashCode ?? 0) ^
-      interactive.hashCode;
+      interactive.hashCode ^
+      Object.hashAll(parts ?? const <CNGlassPart>[]);
 }
 
 /// Extension on Widget to apply Liquid Glass effects.

--- a/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
+++ b/macos/cupertino_native_better/Sources/cupertino_native_better/Views/LiquidGlassContainerNSView.swift
@@ -17,6 +17,7 @@ class LiquidGlassContainerNSView: NSView {
     var tint: NSColor? = nil
     var interactive: Bool = false
     var isDark: Bool = false
+    var parts: [CNGlassPart] = []
 
     if let dict = args as? [String: Any] {
       if let effectStr = dict["effect"] as? String { effect = effectStr }
@@ -32,6 +33,7 @@ class LiquidGlassContainerNSView: NSView {
       }
       if let interactiveBool = dict["interactive"] as? Bool { interactive = interactiveBool }
       if let isDarkBool = dict["isDark"] as? Bool { isDark = isDarkBool }
+      parts = CNGlassPart.list(from: dict["parts"])
     }
 
     // Create SwiftUI view
@@ -40,7 +42,8 @@ class LiquidGlassContainerNSView: NSView {
       shape: shape,
       cornerRadius: cornerRadius,
       tint: tint,
-      interactive: interactive
+      interactive: interactive,
+      parts: parts
     )
 
     self.hostingController = NSHostingController(rootView: glassView)
@@ -108,11 +111,58 @@ class LiquidGlassContainerNSView: NSView {
       shape: shape,
       cornerRadius: cornerRadius,
       tint: tint,
-      interactive: interactive
+      interactive: interactive,
+      parts: CNGlassPart.list(from: dict["parts"])
     )
 
     hostingController.rootView = newGlassView
     hostingController.view.appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
+  }
+}
+
+/// One rounded rectangle of a multi-part glass shape, in points relative to the container's top-left.
+struct CNGlassPart: Equatable {
+  let left: CGFloat
+  let top: CGFloat
+  let width: CGFloat
+  let height: CGFloat
+  let radius: CGFloat
+
+  var rect: CGRect { CGRect(x: left, y: top, width: width, height: height) }
+
+  /// Never rounder than a capsule of that part, so a full-radius square reads as a circle.
+  var clampedRadius: CGFloat { min(radius, min(width, height) / 2.0) }
+
+  static func list(from raw: Any?) -> [CNGlassPart] {
+    guard let entries = raw as? [[String: Any]] else { return [] }
+    return entries.compactMap { entry in
+      guard let left = entry["left"] as? CGFloat,
+            let top = entry["top"] as? CGFloat,
+            let width = entry["width"] as? CGFloat,
+            let height = entry["height"] as? CGFloat,
+            let radius = entry["radius"] as? CGFloat,
+            width > 0, height > 0
+      else { return nil }
+      return CNGlassPart(left: left, top: top, width: width, height: height, radius: radius)
+    }
+  }
+}
+
+/// The parts as one `Shape`. `glassEffect(_:in:)` rims whatever outline it is handed, so a path of
+/// disjoint parts is rimmed on each of them while staying a single effect — one backdrop sample, so
+/// the parts cannot drift apart in colour.
+struct CNGlassPartsShape: Shape, Equatable {
+  let parts: [CNGlassPart]
+
+  func path(in rect: CGRect) -> Path {
+    var path = Path()
+    for part in parts {
+      path.addRoundedRect(
+        in: part.rect,
+        cornerSize: CGSize(width: part.clampedRadius, height: part.clampedRadius)
+      )
+    }
+    return path
   }
 }
 
@@ -123,6 +173,7 @@ struct LiquidGlassContainerSwiftUI: View {
   let cornerRadius: CGFloat?
   let tint: NSColor?
   let interactive: Bool
+  let parts: [CNGlassPart]
 
   var body: some View {
     GeometryReader { geometry in
@@ -144,6 +195,9 @@ struct LiquidGlassContainerSwiftUI: View {
   }
 
   private func shapeForConfig() -> some Shape {
+    if !parts.isEmpty {
+      return AnyShape(CNGlassPartsShape(parts: parts))
+    }
     switch shape {
     case "rect":
       if let radius = cornerRadius {


### PR DESCRIPTION
## Problem

A bar made of two glass pills — a wide one and a lone circle beside it — cannot be built correctly
with the plugin as it stands. There are two ways to try, and each is wrong in a different way.

**One container per pill.** Each pill is its own platform view with its own `.glassEffect`, so each
samples its own backdrop. Over uneven content the two settle on visibly different shades — on the
nav bar this came from, they measured **44/255 apart**. Both pills do keep their rim.

**One container, clipped in Flutter.** A single rect of glass with the two pills cut out of it using
`ClipPath`. One effect means one sample, so the shades match — but `glassEffect(_:in:)` draws its rim
on *the shape it was handed*, which is the rect. The clip then hides almost all of that rim. On the
same bar, the circle kept a rim from **270° round to 90°** — the half that happens to lie along the
rect's own right edge — and had **none from 105° to 255°**.

So today the choice is matching colour *or* a complete rim, never both.

## Root cause

`shapeForConfig()` can only ever return one shape:

```swift
private func shapeForConfig() -> some Shape {
  switch shape {
  case "rect":  ...
  case "circle": ...
  default: Capsule()
  }
}
```

and `glassEffect(_:in:)` rims exactly the outline it is given. A caller who needs two separate
outlines therefore has to either split into two effects (two samples) or clip afterwards (rim drawn
in the wrong place).

## Fix

SwiftUI's `Shape` is free to return a `Path` containing more than one disjoint subpath, and
`glassEffect(_:in:)` accepts any `Shape`. So a path of several rounded rects is still **one effect**
— one backdrop sample, so the parts cannot drift apart — while the rim follows each part's own
outline, because that outline *is* the path.

```swift
struct CNGlassPartsShape: Shape, Equatable {
  let parts: [CNGlassPart]

  func path(in rect: CGRect) -> Path {
    var path = Path()
    for part in parts {
      path.addRoundedRect(
        in: part.rect,
        cornerSize: CGSize(width: part.clampedRadius, height: part.clampedRadius)
      )
    }
    return path
  }
}
```

`shapeForConfig()` returns that when parts are supplied, and is untouched otherwise.

## API

One optional field on `LiquidGlassConfig`:

```dart
LiquidGlassContainer(
  config: LiquidGlassConfig(
    effect: CNGlassEffect.regular,
    parts: <CNGlassPart>[
      CNGlassPart(left: 0,   top: 0, width: 240, height: 64, radius: 32),
      CNGlassPart(left: 250, top: 0, width: 64,  height: 64, radius: 32),
    ],
  ),
  child: const SizedBox.expand(),
)
```

`CNGlassPart` is a rounded rect in logical points relative to the container's own top-left. `radius`
is clamped natively to half the shorter side, so a square at full radius reads as a circle.

**Fully additive and opt-in.** `parts` defaults to `null`, and every existing path — `capsule`,
`rect`, `circle`, `cornerRadius`, `tint`, `interactive` — behaves exactly as before. Nothing changes
for current users unless they pass `parts`.

Included on both platforms: `LiquidGlassContainerView.swift` (iOS) and
`LiquidGlassContainerNSView.swift` (macOS), kept symmetrical with the rest of the file.
`LiquidGlassConfig`'s `==` and `hashCode` take the list into account (`listEquals` /
`Object.hashAll`), so an updated parts list re-sends over the channel like any other config change.

## Repro / verification

There's a demo page in the example app, alongside the existing `pr64_` / `pr66_` / `pr69_` ones:

**PR #77: LiquidGlass parts** → `example/lib/demos/pr77_liquid_glass_parts_test.dart`

It draws the two-pill bar over a deliberately uneven backdrop — a dark block under the left of the
bar, a light one under the right — which is the case that makes two containers disagree. A segmented
control switches between the three modes, and magenta outlines are drawn **in Flutter** on the same
rects the glass is given, so you can see where each pill truly is.

Watch the circle's **left** edge, the side facing the wide pill:

| mode | shades match | circle fully rimmed |
|---|---|---|
| `parts` | ✅ | ✅ |
| `clipped` | ✅ | ❌ no rim on the left side |
| `two views` | ❌ | ✅ |

Verified on an iOS 26 device and simulator. `flutter analyze` clean on `lib` and `example`.

## Notes

Branched from `v1.6.0`, not from any fork history — `d635313` is its only parent, so this is one
commit on top of the current release.

Happy to adjust the naming (`parts` / `CNGlassPart`) or move the shape into its own file if you'd
prefer it separated from the view — I kept it next to `LiquidGlassContainerSwiftUI` to match how the
rest of the file is laid out.
